### PR TITLE
Son/98 account Controller 수정 및 Service Member 엔티티 삭제

### DIFF
--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/controller/AccountApiController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/controller/AccountApiController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,6 +29,18 @@ public class AccountApiController {
 
     private final AccountService accountService;
 
+    //메서드 2개 추가
+    private Long currentMemberId(CurrentUserInfo currentUser) {
+        return Long.parseLong(currentUser.userId());
+    }
+
+    private void assertOwner(CurrentUserInfo currentUser, Long memberId) {
+        Long currentId = currentMemberId(currentUser);
+        if (!currentId.equals(memberId)) {
+            throw new AccessDeniedException("본인 계좌만 접근할 수 있습니다.");
+        }
+    }
+
     //예치금 조회
     @Operation(summary = "예치금 잔액 조회", description = "현재 로그인한 사용자의 예치금 잔액 정보를 조회합니다.")
     @ApiResponses(value = {
@@ -35,12 +48,13 @@ public class AccountApiController {
                     content = @Content(schema = @Schema(implementation = AccountResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     })
-    @GetMapping("/me")
+    @GetMapping("/{memberId}/me")
     public ResponseEntity<AccountResponse> getAccountBalance(
-            @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser
+            @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser,
+            @PathVariable Long memberId
     ){
-        AccountResponse accountResponse = accountService.getAccountBalance(Long.parseLong(currentUser.userId()));
-        return ResponseEntity.ok(accountResponse);
+        assertOwner(currentUser, memberId);
+        return ResponseEntity.ok(accountService.getAccountBalance(memberId));
     }
 
     //예치금 등록
@@ -50,14 +64,17 @@ public class AccountApiController {
                     content = @Content(schema = @Schema(implementation = AccountHistoryResponse.class))),
             @ApiResponse(responseCode = "400", description = "결제 정보 불일치 또는 유효하지 않은 요청", content = @Content)
     })
-    @PostMapping("/charge")
+    @PostMapping("/{memberId}/charge")
     public ResponseEntity<AccountHistoryResponse> chargeAccount(
             @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser,
+            @PathVariable Long memberId,
             @RequestBody PaymentConfirmRequest request
     ) {
 
+        assertOwner(currentUser, memberId);
+
         AccountCommand command = new AccountCommand(
-                Long.parseLong(currentUser.userId()),
+                memberId,
                 request.amount(),
                 request.orderId(),
                 request.paymentKey()
@@ -73,13 +90,14 @@ public class AccountApiController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = AccountHistoryResponse.class))))
     })
-    @GetMapping("/history")
+    @GetMapping("/{memberId}/history")
     public ResponseEntity<List<AccountHistoryResponse>> getAccountHistory(
-            @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser
+            @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser,
+            @PathVariable Long memberId
     ) {
-        List<AccountHistoryResponse> historyList = accountService.getHistoryAll(Long.parseLong(currentUser.userId()));
+        assertOwner(currentUser, memberId);
 
-        return ResponseEntity.ok(historyList);
+        return ResponseEntity.ok(accountService.getHistoryAll(memberId));
     }
 
     // 예치금 내역 상세(단건) 조회
@@ -89,15 +107,16 @@ public class AccountApiController {
                     content = @Content(schema = @Schema(implementation = AccountHistoryResponse.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 내역 ID", content = @Content)
     })
-    @GetMapping("/history/{accountHistoryId}")
+    @GetMapping("/{memberId}/history/{accountHistoryId}")
     public ResponseEntity<AccountHistoryResponse> getAccountHistoryDetail(
             @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser,
+            @PathVariable Long memberId,
             @Parameter(description = "예치금 내역 PK", example = "101") @PathVariable Long accountHistoryId
     ) {
 
-        AccountHistoryResponse response = accountService.getHistory(Long.parseLong(currentUser.userId()), accountHistoryId);
+        assertOwner(currentUser, memberId);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(accountService.getHistory(memberId, accountHistoryId));
     }
 
     // 예치 취소 (환불)
@@ -111,15 +130,17 @@ public class AccountApiController {
                     content = @Content(schema = @Schema(implementation = AccountHistoryResponse.class))),
             @ApiResponse(responseCode = "400", description = "환불 가능 금액 부족 또는 기간 만료", content = @Content)
     })
-    @PostMapping("/history/{accountHistoryId}/cancel")
+    @PostMapping("/{memberId}/history/{accountHistoryId}/cancel")
     public ResponseEntity<AccountHistoryResponse> cancelHistory(
             @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser,
+            @PathVariable Long memberId,
             @Parameter(description = "취소할 내역 PK", example = "101") @PathVariable Long accountHistoryId,
             @RequestBody @Valid TossCancelRequest request
     ) {
 
+        assertOwner(currentUser, memberId);
         AccountHistoryResponse response=accountService.deleteHistory(
-                Long.parseLong(currentUser.userId()),
+                memberId,
                 accountHistoryId,
                 request.cancelReason()
         );
@@ -129,3 +150,12 @@ public class AccountApiController {
 
 
 }
+
+/*
+memberid : 사용자가 조작할 수 있는 id
+currentUser: 인증된 사용자
+사용자가 memberid를 입력/조작 할 수 있으므로 컨트롤러에서 currentUser.userId()와 memberId를 비교해서 같을 때만 통과시키고 통과 후에만
+서비스에 memberId를 넘긴다.
+memberId를 넘기는 이유: 컨트롤러에서 asserOwner()로 요청자(currentUser)와 대상(memberId)이 같은지 검증을 한 뒤, 그 검증된
+memberId로 서비스에 넘기는 게 정상 패턴.
+ */

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/model/entity/Account.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/model/entity/Account.java
@@ -1,6 +1,5 @@
 package io.codebuddy.closetbuddy.domain.accounts.model.entity;
 
-import io.codebuddy.closetbuddy.domain.common.model.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,19 +20,18 @@ public class Account {
     @Column(name = "balance")
     private Long balance;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "id", nullable = false, unique = true)
-    private Member member;
+    @Column(name = "member_id", nullable = false, unique = true)
+    private Long memberId;
 
     @Builder
-    public Account(Long accountId,Long balance,Member member){
+    public Account(Long accountId,Long balance, Long memberId){
         this.accountId=accountId;
         this.balance=0L;
-        this.member=member;
+        this.memberId=memberId;
     }
-    public static Account createAccount(Member member) {
+    public static Account createAccount(Long memberId) {
         return Account.builder()
-                .member(member)
+                .memberId(memberId)
                 .balance(0L)
                 .build();
     }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/model/entity/DepositCharge.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/model/entity/DepositCharge.java
@@ -1,7 +1,6 @@
 package io.codebuddy.closetbuddy.domain.accounts.model.entity;
 
 import io.codebuddy.closetbuddy.domain.accounts.model.vo.ChargeStatus;
-import io.codebuddy.closetbuddy.domain.common.model.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,9 +20,8 @@ public class DepositCharge {
     @Column(name = "charge_id")
     private Long chargeId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @Column(name = "member_id")
+    private Long memberId;
 
     @Column(name = "pg_payment_key")
     private String pgPaymentKey;
@@ -45,9 +43,9 @@ public class DepositCharge {
     private LocalDateTime createdAt;
 
     @Builder
-    public DepositCharge(Long chargeId, Member member, String pgPaymentKey, String pgOrderId, Long chargeAmount, ChargeStatus status, LocalDateTime createdAt, LocalDateTime approvedAt){
+    public DepositCharge(Long chargeId, Long memberId, String pgPaymentKey, String pgOrderId, Long chargeAmount, ChargeStatus status, LocalDateTime createdAt, LocalDateTime approvedAt){
         this.chargeId=chargeId;
-        this.member=member;
+        this.memberId=memberId;
         this.pgPaymentKey=pgPaymentKey;
         this.pgOrderId=pgOrderId;
         this.chargeAmount=chargeAmount;

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/model/mapper/AccountMapper.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/model/mapper/AccountMapper.java
@@ -14,7 +14,7 @@ public class AccountMapper {
     // Account(entity) -> AccountResponse(vo)
     public static AccountResponse toResponse(Account account, String message) {
         return new AccountResponse(
-                account.getMember().getId(),
+                account.getMemberId(),
                 account.getBalance(),
                 message
         );

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/repository/AccountRepository.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/repository/AccountRepository.java
@@ -1,13 +1,10 @@
 package io.codebuddy.closetbuddy.domain.accounts.repository;
 
 import io.codebuddy.closetbuddy.domain.accounts.model.entity.Account;
-import io.codebuddy.closetbuddy.domain.common.model.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account,Long> {
-    Optional<Account> findByMember(Member member);
-
     Optional<Account> findByMemberId(Long memberId);
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/service/AccountServiceImpl.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/accounts/service/AccountServiceImpl.java
@@ -13,8 +13,6 @@ import io.codebuddy.closetbuddy.domain.accounts.model.vo.*;
 import io.codebuddy.closetbuddy.domain.accounts.repository.AccountHistoryRepository;
 import io.codebuddy.closetbuddy.domain.accounts.repository.AccountRepository;
 import io.codebuddy.closetbuddy.domain.accounts.repository.DepositChargeRepository;
-import io.codebuddy.closetbuddy.domain.common.model.entity.Member;
-import io.codebuddy.closetbuddy.domain.common.repository.MemberRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +37,6 @@ import java.util.Optional;
 public class AccountServiceImpl implements AccountService{
 
     private final ObjectMapper om;
-    private final MemberRepository memberRepository;
     private final AccountRepository accountRepository;
     private final AccountHistoryRepository accountHistoryRepository;
     private final DepositChargeRepository depositChargeRepository;
@@ -62,13 +59,7 @@ public class AccountServiceImpl implements AccountService{
     @Transactional(readOnly=true)
     public AccountResponse getAccountBalance(Long memberId) {
 
-        Optional<Member> memberOptional=memberRepository.findById(memberId);
-
-        Member foundMember=memberOptional.orElseThrow(
-                ()->new IllegalArgumentException("존재하지 않는 회원입니다.")
-        );
-
-        Account account = accountRepository.findByMember(foundMember).orElse(Account.createAccount(foundMember));
+        Account account = accountRepository.findByMemberId(memberId).orElse(Account.createAccount(memberId));
 
         return AccountMapper.toResponse(account, "조회가 완료되었습니다.");
     }
@@ -100,14 +91,10 @@ public class AccountServiceImpl implements AccountService{
             throw new IllegalStateException("요청 금액과 실제 결제 금액이 일치하지 않습니다.");
         }
 
-        // 회원 검증
-        Member foundMember = memberRepository.findById(command.getMemberId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-
         // 계좌 조회
-        Account account = accountRepository.findByMember(foundMember)
+        Account account = accountRepository.findByMemberId(command.getMemberId())
                 .orElseGet(() -> {
-                    Account newAccount = Account.createAccount(foundMember);
+                    Account newAccount = Account.createAccount(command.getMemberId());
                     return accountRepository.save(newAccount);
                 });
 
@@ -122,7 +109,7 @@ public class AccountServiceImpl implements AccountService{
 
         //pg 결제 내역 저장
         DepositCharge charge = DepositCharge.builder()
-                .member(foundMember)
+                .memberId(command.getMemberId())
                 .pgPaymentKey(paymentSuccessDto.getPaymentKey())
                 .pgOrderId(command.getOrderId())
                 .chargeAmount(command.getAmount())
@@ -157,15 +144,10 @@ public class AccountServiceImpl implements AccountService{
     @Override
     @Transactional(readOnly = true)
     public List<AccountHistoryResponse> getHistoryAll(Long memberId) {
-        Optional<Member> memberOptional=memberRepository.findById(memberId);
-
-        Member foundMember=memberOptional.orElseThrow(
-                ()->new IllegalArgumentException("존재하지 않는 회원입니다.")
-        );
 
         // 계좌 조회
         // 계좌가 아예 없다면 -> 내역도 없음 -> 빈 리스트 반환
-        Account account = accountRepository.findByMember(foundMember)
+        Account account = accountRepository.findByMemberId(memberId)
                 .orElse(null);
 
         if (account == null) {
@@ -195,10 +177,7 @@ public class AccountServiceImpl implements AccountService{
     @Transactional(readOnly = true)
     public AccountHistoryResponse getHistory(Long memberId, Long historyId) {
 
-        Member foundMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-
-        Account account = accountRepository.findByMember(foundMember)
+        Account account = accountRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("계좌가 존재하지 않습니다."));
 
         // 내역 단건 조회
@@ -229,12 +208,9 @@ public class AccountServiceImpl implements AccountService{
     @Override
     @Transactional
     public AccountHistoryResponse deleteHistory(Long memberId, Long historyId,String reason) {
-        // 멤버 검증
-        Member foundMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
         // 계좌 검증
-        Account account = accountRepository.findByMember(foundMember)
+        Account account = accountRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("계좌가 존재하지 않습니다."));
 
         // 내역 조회 (내 계좌의 내역인지 확인)


### PR DESCRIPTION
## 🔗 관련 이슈
- msa로 인한 MemberEntity 제거로 인해 account에 Member 엔티티 연결 끊음 필요
---

## 🧩 구현한 기능
- [x] 주요 기능 1 입력한 회원정보와 인증된 회원정보를 비교하여 동일한지 판단하는 부분controller에 추가
- [x] 주요 기능 2 service에서 Member Entity 부분 삭제

