### PR TITLE
[#107] 장바구니 객체 잠조 종속성 제거 및 Id 참조 변환

### DIFF
--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/carts/controller/CartController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/carts/controller/CartController.java
@@ -61,9 +61,8 @@ public class CartController {
     }
 
     /**
-     * 장바구니를 조회합니다.
-     * 회원 아이디를 통해 조회합니다.
-     * @param memberPrincipalDetails
+     * 회원 아이디를 통해 장바구니를 조회합니다.
+     * @param currentUser
      * @return
      */
     @Operation(
@@ -95,9 +94,9 @@ public class CartController {
 
 
     /**
-     * memberId를 통해 장바구니 수량을 수정합니다.
-     * 수량이 1개 미만으로 떨어지면 예외를 발생시킵니다.
-     * @param memberPrincipal
+     * 장바구니 수량을 수정합니다.
+     * 수량이 1개 미만이면 예외를 발생시킵니다.
+     * @param currentUser
      * @param cartItemId
      * @param cartCount
      * @return
@@ -138,7 +137,7 @@ public class CartController {
 
     /**
      * 장바구니의 물건을 삭제합니다.
-     * @param memberPrincipal
+     * @param currentUser
      * @param cartItemId
      * @return
      */

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/carts/entity/Cart.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/carts/entity/Cart.java
@@ -1,6 +1,5 @@
 package io.codebuddy.closetbuddy.domain.carts.entity;
 
-import io.codebuddy.closetbuddy.domain.common.model.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,18 +20,17 @@ public class Cart {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @Column(name = "member_id")
+    private Long memberId;
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CartItem> cartItems = new ArrayList<>();
 
     // 생성자
     @Builder
-    public static Cart createCart(Member member) {
+    public static Cart createCart(Long memberId) {
         Cart cart = new Cart();
-        cart.member = member;
+        cart.memberId = memberId;
         return cart;
     }
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/carts/service/CartService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/carts/service/CartService.java
@@ -1,6 +1,5 @@
 package io.codebuddy.closetbuddy.domain.carts.service;
 
-import io.codebuddy.closetbuddy.domain.common.repository.MemberRepository;
 import io.codebuddy.closetbuddy.domain.carts.dto.request.CartCreateRequestDto;
 import io.codebuddy.closetbuddy.domain.carts.dto.response.CartGetResponseDto;
 import io.codebuddy.closetbuddy.domain.carts.entity.Cart;
@@ -8,7 +7,6 @@ import io.codebuddy.closetbuddy.domain.carts.entity.CartItem;
 import io.codebuddy.closetbuddy.domain.carts.repository.CartItemRepository;
 import io.codebuddy.closetbuddy.domain.carts.repository.CartRepository;
 
-import io.codebuddy.closetbuddy.domain.common.model.entity.Member;
 import io.codebuddy.closetbuddy.domain.products.model.entity.Product;
 import io.codebuddy.closetbuddy.domain.products.repository.ProductJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +23,6 @@ public class CartService {
 
     private final CartRepository cartRepository;
     private final CartItemRepository cartItemRepository;
-    private final MemberRepository memberRepository;
     private final ProductJpaRepository productJpaRepository;
 
 
@@ -40,8 +37,9 @@ public class CartService {
     public Long createCart(Long memberId, CartCreateRequestDto request) {
 
         // 1. 회원 조회
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다."));
+        if(memberId == null) {
+            throw new IllegalArgumentException("회원이 존재하지 않습니다.");
+        }
 
         // 2. 상품 조회
         Product product = productJpaRepository.findById(request.productId())
@@ -50,7 +48,7 @@ public class CartService {
         // 장바구니 조회 없으면 생성
         Cart cart = cartRepository.findByMemberId(memberId)
                 .orElseGet(() -> {
-                    Cart newCart = Cart.createCart(member);
+                    Cart newCart = Cart.createCart(memberId);
                     return cartRepository.save(newCart);
                 });
 
@@ -97,7 +95,7 @@ public class CartService {
         CartItem cartItem = cartItemRepository.findById(cartItemId)
                 .orElseThrow(() -> new IllegalArgumentException(""));
 
-        if (!cartItem.getCart().getMember().getId().equals(memberId)) {
+        if (!cartItem.getCart().getMemberId().equals(memberId)) {
             throw new IllegalArgumentException("수정 권한이 없습니다.");
         }
 
@@ -115,7 +113,7 @@ public class CartService {
         CartItem cartItem = cartItemRepository.findById(cartItemId)
                 .orElseThrow(() -> new IllegalArgumentException("장바구니에 없는 상품입니다."));
 
-        if (!cartItem.getCart().getMember().getId().equals(memberId)) {
+        if (!cartItem.getCart().getMemberId().equals(memberId)) {
             throw new IllegalArgumentException("삭제 권한이 없습니다.");
         }
 


### PR DESCRIPTION
객체 참조 종속성을 끊고 Id 참조로 변환하였습니다.

## 🔗 관련 이슈
- Closes #107 

---

## 🧩 구현한 기능
- [x] Cart 엔티티에 작성한 객체 참조를 ID 참조로 변환
- [x] Cart Service에 작성한 객체 참조를 ID 참조로 변환
- [x] 주석에 들어있는 memberprincipal와 불필요한 주석 제거

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 ~ 요청
2. 서버에서 ~ 처리
3. 결과를 ~ 형태로 반환

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 객체 참조 로직에서 ID 참조로 변환

### 🗂 구조 변경
- 패키지 구조 변경 여부
- 새로 추가 / 삭제된 클래스

---

## 🧪 테스트 방법
- [ ] 로컬 테스트 완료
- [ ] 단위 테스트 추가 / 수정
- [ ] Postman / Swagger 테스트

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한지 확인 부탁드립니다.
- 예외 처리 방식에 대한 의견을 주시면 좋겠습니다.
- 성능 또는 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] 후속 기능 구현
- [ ] 성능 개선
- [ ] 예외 처리 보완
- [ ] 테스트 코드 보강
