### PR TITLE
son/111 JWT 필터 내부에서 발생하는 예외, 인증/ 인가 최종 실패(401/403) 를 처리하는 코드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ application.yml
 src/main/resources/docker-compose.yml
 */docker-compose.yml
 docker-compose.yml
+docker-compose-test.yml
 
 ### STS ###
 .apt_generated

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/app/JwtTokenProvider.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/app/JwtTokenProvider.java
@@ -74,31 +74,14 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    // 검증 메서드
-    public boolean validate(String token) {
+    // 기존 검증 메서드 코드의 단점: false만 리턴하면, 호출한 쪽(JwtAuthenticationFilter)은 왜 실패했는지 알 방법이 없음.
+    public void validate(String token) {
 
-        try {
-            Jwts.parser()
-                    .verifyWith(getSecretKey())
-                    .build()
-                    .parseSignedClaims(token);
-
-            return true;
-
-        } catch ( JwtException e ) {
-            log.error("token = {}", token);
-            log.error("JWT 토큰에 문제가 있습니다.");
-
-        } catch ( IllegalStateException e ) {
-            log.error("token = {}", token);
-            log.error("이상한 토큰이 검출되었습니다.");
-
-        } catch (Exception e) {
-            log.error("token = {}", token);
-            log.error(";;");
-        }
-
-        return false;
+        Jwts.parser()
+                .verifyWith(getSecretKey())
+                .build()
+                .parseSignedClaims(token);
+        // 예외가 발생하지 않으면 정상 통과
 
     }
 

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/SecurityConfig.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/SecurityConfig.java
@@ -1,6 +1,10 @@
 package io.codebuddy.userservice.domain.common.config;
 
 
+import io.codebuddy.userservice.domain.common.security.handler.CustomAuthenticationEntryPoint;
+import io.codebuddy.userservice.domain.common.security.auth.JwtExceptionFilter;
+import io.codebuddy.userservice.domain.common.security.auth.JwtAuthenticationFilter;
+import io.codebuddy.userservice.domain.common.security.handler.CustomAccessDeniedHandler;
 import io.codebuddy.userservice.domain.form.login.security.config.CustomAuthenticationFailureHandler;
 import io.codebuddy.userservice.domain.form.login.security.config.MemberAuthSuccessHandler;
 import io.codebuddy.userservice.domain.form.logout.config.ApiLogoutSuccessHandler;
@@ -16,7 +20,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsUtils;
 
@@ -29,11 +32,17 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 
+    private final JwtExceptionFilter jwtExceptionFilter; // [추가]
+
     private final MemberAuthSuccessHandler memberAuthSuccessHandler;
     private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
     private final JwtLogoutHandler jwtLogoutHandler;
 
     private final ApiLogoutSuccessHandler apiLogoutSuccessHandler;
+
+    // [추가]
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public AuthenticationManager authenticationManager(
@@ -90,11 +99,22 @@ public class SecurityConfig {
                         .logoutSuccessHandler(apiLogoutSuccessHandler)
                 )
 
+                // 인증/인가 예외 처리
+                .exceptionHandling(handling -> handling
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                )
+
                 //OAuth2 로그인 활성화
                 .oauth2Login(oauth -> {
                     oauth.successHandler(oAuth2SuccessHandler);
                 })
+
+
+                // 필터 순서: JwtExceptionFilter -> JwtAuthenticationFilter -> UsernamePasswordAuthenticationFilter
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class) // [추가]
+
                 .build();// 필터 체인 빌드
 
     }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/auth/JwtAuthenticationFilter.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/auth/JwtAuthenticationFilter.java
@@ -1,8 +1,7 @@
-package io.codebuddy.userservice.domain.common.config;
+package io.codebuddy.userservice.domain.common.security.auth;
 
 import io.codebuddy.userservice.domain.common.app.JwtTokenProvider;
 import io.codebuddy.userservice.domain.common.model.dto.TokenBody;
-import io.codebuddy.userservice.domain.common.security.auth.MemberDetails;
 import io.codebuddy.userservice.domain.oauth.service.OauthService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -35,7 +34,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
-        if ( token != null && jwtTokenProvider.validate(token) ) {
+        if (token != null ) {
+            // validate()에서 예외가 발생하면 JwtExceptionFilter로 전파됨
+            jwtTokenProvider.validate(token);
 
             TokenBody tokenBody = jwtTokenProvider.parseJwt(token);
             MemberDetails memberPrincipalDetails = oauthService.getMemberDetailsById(tokenBody.getMemberId());

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/auth/JwtExceptionFilter.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/auth/JwtExceptionFilter.java
@@ -1,0 +1,70 @@
+package io.codebuddy.userservice.domain.common.security.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import io.jsonwebtoken.security.SignatureException;
+import java.util.HashMap;
+import java.util.Map;
+
+// JwtTokenProvider 에서 난 예외를 JwtAuthenticationFilter 를 거쳐서 예외를 발생시키는 메서드
+// 제시된 토큰의 상태를 알리는 메서드
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException{
+        try {
+            // 다음 필터(JwtAuthenticationFilter)로 진행
+            filterChain.doFilter(request, response);
+
+        } catch (ExpiredJwtException e) {
+            // 토큰 만료
+            log.warn("토큰 만료: {}", e.getMessage());
+            setErrorResponse(response, "TOKEN_EXPIRED", "토큰이 만료되었습니다. 토큰을 재발급 받으세요.");
+
+        } catch (SignatureException e) {
+            // 토큰 서명 위조/변조
+            log.error("토큰 위조 감지: {}", e.getMessage());
+            setErrorResponse(response, "TOKEN_INVALID_SIGNATURE", "유효하지 않은 토큰 서명입니다.");
+
+        } catch (MalformedJwtException e) {
+            // 토큰 형식 오류
+            log.error("토큰 형식 오류: {}", e.getMessage());
+            setErrorResponse(response, "TOKEN_MALFORMED", "토큰 형식이 올바르지 않습니다.");
+
+        } catch (JwtException | IllegalArgumentException e) {
+            // 기타 JWT 관련 오류
+            log.error("JWT 처리 오류: {}", e.getMessage());
+            setErrorResponse(response, "TOKEN_ERROR", "토큰 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, String code, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", code);
+        body.put("message", message);
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/handler/AuthExceptionHandler.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/handler/AuthExceptionHandler.java
@@ -1,0 +1,39 @@
+package io.codebuddy.userservice.domain.common.security.handler;
+
+import io.codebuddy.userservice.domain.common.exception.InvalidTokenException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+@ExceptionHandler: @controller, @RestController가 적용된 Bean 내에서 발생하는 예외를 잡아서 하나의 메서드에서 처리해주는 기능을 한다.
+@RestControllerAdvice: 모든 @Controller, 즉 전역에서 발생할 수 있는 예외를 잡아주는 어노테이션
+TokenRefreshService 관련 예외처리 메서드
+해당 어노테이션들을 써준 이유: TokenRefreshService에서 예외가 터지면 컨트롤러로 던져지기 때문에
+ */
+@RestControllerAdvice
+public class AuthExceptionHandler {
+    // Refresh Token 검증 실패 처리
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidToken(InvalidTokenException e) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", "INVALID_REFRESH_TOKEN");
+        body.put("message", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    // 기타 예상치 못한 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGeneralException(Exception e) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", "INTERNAL_SERVER_ERROR");
+        body.put("message", "서버 오류가 발생했습니다.");
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/handler/CustomAccessDeniedHandler.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package io.codebuddy.userservice.domain.common.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// 인증이 완료되었으나 해당 엔드포인트에 접근할 권한이 없는 경우 예외를 날려주는 핸들러
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", "ACCESS_DENIED");
+        body.put("message", "접근 권한이 없습니다.");
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/handler/CustomAuthenticationEntryPoint.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package io.codebuddy.userservice.domain.common.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+인증이 안된 익명의 사용자가 인증이 필요한 엔드포인트로 접근하려할 때 예외를 핸들링해주도록 도와주는 메서드
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", "UNAUTHORIZED");
+        body.put("message", "인증이 필요합니다.");
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}


### PR DESCRIPTION
JWT 필터 내부에서 발생하는 예외, 인증/ 인가 최종 실패(401/403) 를 처리하는 코드 추가

## 🔗 관련 이슈
- 예외 처리 필요

---

## 🧩 구현한 기능
- [ ] 주요 기능 1  JWT 필터 내부에서 발생하는 예외처리 추가하기
- [ ] 주요 기능 2 인증/ 인가 최종 실패(401/403) 를 처리하는 코드 추가하기

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 ~ 요청
2. 서버에서 ~ 처리
3. 결과를 ~ 형태로 반환

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 로직에서 ~ 방식으로 변경
- 공통 로직 리팩토링

### 🗂 구조 변경
- 패키지 구조 변경 여부
- 새로 추가 / 삭제된 클래스

---

## 🧪 테스트 방법
- [ ] 로컬 테스트 완료
- [ ] 단위 테스트 추가 / 수정
- [ ] Postman / Swagger 테스트

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한지 확인 부탁드립니다.
- 예외 처리 방식에 대한 의견을 주시면 좋겠습니다.
- 성능 또는 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] 후속 기능 구현
- [ ] 성능 개선
- [ ] 예외 처리 보완
- [ ] 테스트 코드 보강
