### PR TITLE
-[#122] TokenVerifyController 토큰 유효성 검증 방식 변경

### DIFF
--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/controller/TokenVerifyController.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/controller/TokenVerifyController.java
@@ -2,35 +2,42 @@ package io.codebuddy.userservice.domain.common.controller;
 
 import io.codebuddy.userservice.domain.common.app.JwtTokenProvider;
 import io.codebuddy.userservice.domain.common.model.dto.TokenBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
 public class TokenVerifyController {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public TokenVerifyController(JwtTokenProvider jwtTokenProvider) {
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
-
-    public record VerifyResponse(Long userId, String role) {
-    }
+    public record VerifyResponse(Long userId, String role) {}
 
     @PostMapping("/verify")
     public ResponseEntity<VerifyResponse> verify(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+
+        // 토큰 추출
         String token = extractBearerToken(authHeader);
-        if (token == null || !jwtTokenProvider.validate(token)) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+        // 토큰이 아예 없는 경우만 컨트롤러에서 401 예외처리
+        if (token == null) {
+            return ResponseEntity.status(401).build();
         }
 
+        // 토큰 파싱 검증 포함
+        // 여기서 만료/위조 등의 문제가 있으면 'JwtTokenProvider'가 예외를 throw
+        // -> 컨트롤러 밖으로 예외 전파 -> 'JwtExceptionFilter'가 예외 잡아서 JSON 응답 생성
         TokenBody body = jwtTokenProvider.parseJwt(token);
+        //정상적으로 문제 없이 파싱되면 검증 response 반환
+
         return ResponseEntity.ok(new VerifyResponse(body.getMemberId(), body.getRole().name()));
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #122

---

## 🧩 구현한 기능
- [ ] TokenVerifyController 토큰 유효성 검증 방식을 예외 필터를 통한 방식으로 변경
---

## ✨ 변동 사항
### 🔧 코드 변경
- TokenVerifyController에서 토큰 유효성 검증을 validate 를 사용하는 방식에서 예외필터로 예외를 받아 처리하는 방식으로 변경


### 🗂 구조 변경
- validate 사용 X
---

## 🚀 예상 추가 작업
- [ ] 현재 판매자 등록이 동기로 처리되어야 하나, 해당 로직이 존재 X -> 동기방식 gateway 통신 요청 필요
- [ ] 추후 kafka 도입시 비동기 이벤트 방식 처리 필요
