### PR TITLE
[#127] 판매자, 상점, 상품 도메인 예외처리 및 핸들러 적용

### DIFF
--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/controller/ProductApiController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/controller/ProductApiController.java
@@ -50,6 +50,11 @@ public class ProductApiController {
             @PathVariable Long storeId,
             @RequestBody @Valid ProductCreateRequest request
     ) {
+
+        if (storeId == null || storeId <= 0) {
+            throw new IllegalStateException("유효하지 않는 상점 ID입니다.");
+        }
+
         Long productId = productService.createProduct(Long.parseLong(currentUser.userId()), storeId, request);
         return ResponseEntity.ok(productId);
     }
@@ -73,6 +78,11 @@ public class ProductApiController {
     public ResponseEntity<ProductResponse> getProduct(
             @PathVariable Long productId
     ) {
+
+        if (productId == null || productId <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 상품 ID입니다.");
+        }
+
         ProductResponse response = productService.getProduct(productId);
         return ResponseEntity.ok(response);
     }
@@ -96,6 +106,11 @@ public class ProductApiController {
     public ResponseEntity<List<ProductResponse>> getProductsByStore(
             @PathVariable Long storeId
     ) {
+
+        if (storeId == null || storeId <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 상점 ID입니다.");
+        }
+
         List<ProductResponse> response = productService.getProductByStoreId(storeId);
         return ResponseEntity.ok(response);
     }
@@ -125,6 +140,11 @@ public class ProductApiController {
             @PathVariable Long productId,
             @RequestBody @Valid UpdateProductRequest request
     ) {
+
+        if (productId == null || productId <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 상품 ID입니다.");
+        }
+
         productService.updateProduct(Long.parseLong(currentUser.userId()), productId, request);
         return ResponseEntity.ok().build();
     }
@@ -150,6 +170,11 @@ public class ProductApiController {
             @CurrentUser CurrentUserInfo currentUser,
             @PathVariable Long productId
     ) {
+
+        if (productId == null || productId <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 상품 ID입니다.");
+        }
+
         productService.deleteProduct(Long.parseLong(currentUser.userId()), productId);
         return ResponseEntity.noContent().build();
     }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/controller/ProductExceptionHandler.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/controller/ProductExceptionHandler.java
@@ -1,0 +1,73 @@
+package io.codebuddy.closetbuddy.domain.products.controller;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+//product 도메인에 걸쳐 예외를 처리하는 핸들러
+@RestControllerAdvice(basePackageClasses = ProductApiController.class)
+@Slf4j
+public class ProductExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        //상품 요청에 대한 예외 메시지 추출
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        //서버 로그에 검증 메시지 출력
+        log.warn("상품 요청 검증 실패: {}", message);
+        //요청 반환으로 메시지 출력
+        return errorResponse(HttpStatus.BAD_REQUEST, message);
+    }
+
+    //상품 요청 제약 조건 위반 예외 처리 핸ㄷ늘러
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Map<String, String>> handleConstraintViolation(ConstraintViolationException exception) {
+        //원인 서버 로그 출력
+        log.warn("상품 요청 제약 조건 위반: {}", exception.getMessage());
+        //반환값 메시지 출력
+        return errorResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
+    }
+
+    //요청값 유효성 예외처리 핸들러
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+        HttpStatus status = resolveStatus(ex.getMessage());
+        //서버 로그 출력
+        log.warn("상품 처리 오류: {}", ex.getMessage());
+        //예외 응답 메시지 반환
+        return errorResponse(status, ex.getMessage());
+    }
+
+    //서버에러(주로) 핸들러
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleException(Exception ex) {
+        log.error("상품 처리 중 서버 오류", ex);
+        return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "상품 처리 중 오류가 발생했습니다.");
+    }
+
+    //상품 삭제 혹은 요청 유저 존재 확인 예외처리 핸들러
+    private HttpStatus resolveStatus(String message) {
+        if (message != null && (message.contains("없습니다") || message.contains("존재하지"))) {
+            log.warn(message);
+            return HttpStatus.NOT_FOUND;
+        }
+        log.warn(message);
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    private ResponseEntity<Map<String, String>> errorResponse(HttpStatus status, String message) {
+        Map<String, String> error = new HashMap<>();
+        error.put("message", message);
+        return ResponseEntity.status(status).body(error);
+    }
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/model/dto/ProductCreateRequest.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/model/dto/ProductCreateRequest.java
@@ -2,23 +2,25 @@ package io.codebuddy.closetbuddy.domain.products.model.dto;
 
 import io.codebuddy.closetbuddy.domain.products.model.entity.Product;
 import io.codebuddy.closetbuddy.domain.stores.model.entity.Store;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 public record ProductCreateRequest(
         @NotBlank(message = "상품명은 필수입니다.")
+        @Size(min = 1, max = 50, message = "상품명은 1글자 이상 50자 미만이어야합니다.")
         String productName,
 
         @NotNull(message = "상품 가격은 필수입니다.")
-        @Min(value = 0, message = "가격은 최소 0원 이상이엉야 합니다.")
+        @Min(value = 0, message = "가격은 최소 0원 이상이어야 합니다.")
+        @Max(value = 1000000000, message = "상품 가격의 상한선은 10억원 입니다.")
         Long productPrice,
 
         @Min(value = 0, message = "재고는 0개 이상이어야 합니다.")
         int productStock,
 
+        @Size(min = 3, max = 999999, message = "Url 경로 길이를 확인하세요")
         String imgUrl,
 
+        @Size(min = 1, max = 9999, message = "카테고리 이름 길이를 확인하세요(1~9999)")
         Category category
 ) {
     public Product toEntity(Store store) {

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/model/dto/ProductResponse.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/model/dto/ProductResponse.java
@@ -1,14 +1,12 @@
 package io.codebuddy.closetbuddy.domain.products.model.dto;
 
 import io.codebuddy.closetbuddy.domain.products.model.entity.Product;
-import io.codebuddy.closetbuddy.domain.stores.model.entity.Store;
 
 public record ProductResponse(
         Long productId,
         String productName,
         Long productPrice,
         int productStock,
-
         Category category,
         String storeName
 ) {
@@ -21,7 +19,6 @@ public record ProductResponse(
                 product.getProductPrice(),
                 product.getProductStock(),
                 product.getCategory(),
-                        //!= null ? product.getCategory().name() : "Uncategorized",
                 product.getStore().getStoreName()
         );
     }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/model/dto/UpdateProductRequest.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/products/model/dto/UpdateProductRequest.java
@@ -1,14 +1,19 @@
 package io.codebuddy.closetbuddy.domain.products.model.dto;
 
-import io.codebuddy.closetbuddy.domain.stores.model.entity.Store;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 public record UpdateProductRequest(
-        @NotBlank String productName,
-        @NotNull Long productPrice,
+        @NotBlank (message = "상품명은 필수입니다.")
+        String productName,
+        @NotNull (message = "상품 가격은 필수입니다.")
+        @Min(value = 0, message = "상품 가격은 최소 0원 이상이어야 합니다.")
+        @Max(value = 100000000, message = "상품 가격은 최대 10억원 이하입니다.")
+        Long productPrice,
+        @Min(value = 0, message = "상품 재고는 0개 이상이어야 합니다.")
         int productStock,
+        @Size(min = 3, max = 999999, message = "Url 경로 길이를 확인하세요")
         String imageUrl,
+        @Size(min = 1, max = 9999, message = "카테고리 이름 길이를 확인하세요(1~9999)")
         Category category
 ) {
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/sellers/controller/SellerExceptionHandler.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/sellers/controller/SellerExceptionHandler.java
@@ -1,0 +1,61 @@
+package io.codebuddy.closetbuddy.domain.sellers.controller;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice(basePackageClasses = SellerApiController.class)
+@Slf4j
+public class SellerExceptionHandler {
+
+    //판매자 요청 검증 예외 핸들러
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("판매자 요청 검증 실패: {}", message);
+        return errorResponse(HttpStatus.BAD_REQUEST, message);
+    }
+
+    //판매자 제약조건 예외 핸들러
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Map<String, String>> handleConstraintViolation(ConstraintViolationException ex) {
+        log.warn("판매자 요청 제약 조건 위반: {}", ex.getMessage());
+        return errorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+        HttpStatus status = resolveStatus(ex.getMessage());
+        log.warn("판매자 처리 오류: {}", ex.getMessage());
+        return errorResponse(status, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleException(Exception ex) {
+        log.error("판매자 처리 중 서버 오류", ex);
+        return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "판매자 처리 중 오류가 발생했습니다.");
+    }
+
+    private HttpStatus resolveStatus(String message) {
+        if (message != null && (message.contains("없습니다") || message.contains("존재하지"))) {
+            return HttpStatus.NOT_FOUND;
+        }
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    private ResponseEntity<Map<String, String>> errorResponse(HttpStatus status, String message) {
+        Map<String, String> error = new HashMap<>();
+        error.put("message", message);
+        return ResponseEntity.status(status).body(error);
+    }
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/contorller/StoreApiController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/contorller/StoreApiController.java
@@ -73,6 +73,10 @@ public class StoreApiController {
     public ResponseEntity<StoreResponse> getOneStore(
             @PathVariable Long store_id
     ) {
+        if (store_id == null || store_id <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 상점 ID입니다.");
+        }
+
         StoreResponse response = storeService.getStore(store_id);
         return ResponseEntity.ok(response);
     }
@@ -117,7 +121,6 @@ public class StoreApiController {
                     responseCode = "404",
                     description = "가게 데이터 없음"
             )
-
     })
     @PutMapping("stores/{store_id}")
     public ResponseEntity<StoreResponse> updateStore(
@@ -125,6 +128,11 @@ public class StoreApiController {
             @PathVariable Long store_id,
             @RequestBody @Valid UpdateStoreRequest request
             ) {
+
+        if (store_id == null || store_id <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 상점 ID입니다.");
+        }
+
         storeService.updateStore(Long.parseLong(currentUser.userId()), store_id, request);
         return ResponseEntity.ok().build();
     }
@@ -150,6 +158,9 @@ public class StoreApiController {
             @CurrentUser CurrentUserInfo currentUser,
             @PathVariable Long store_id
     ) {
+        if (store_id == null || store_id <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 상점 ID입니다.");
+        }
         storeService.deleteStore(Long.parseLong(currentUser.userId()), store_id);
         return ResponseEntity.noContent().build();
     }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/contorller/StoreExceptionHandler.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/contorller/StoreExceptionHandler.java
@@ -1,0 +1,63 @@
+package io.codebuddy.closetbuddy.domain.stores.contorller;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice(basePackageClasses = StoreApiController.class)
+@Slf4j
+public class StoreExceptionHandler {
+
+    //상점 요청 검증 메시지 핸들러 응답 출력
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        //서버 로그 출력
+        log.warn("상점 요청 검증 실패: {}", message);
+        return errorResponse(HttpStatus.BAD_REQUEST, message);
+    }
+
+    //상점 요청 파라미터 제약조건 위반 예외 핸들러 응답 출력
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Map<String, String>> handleConstraintViolation(ConstraintViolationException ex) {
+        //서버 로그 출력
+        log.warn("상점 요청 제약 조건 위반: {}", ex.getMessage());
+        return errorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+        HttpStatus status = resolveStatus(ex.getMessage());
+        log.warn("상점 처리 오류: {}", ex.getMessage());
+        return errorResponse(status, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleException(Exception ex) {
+        log.error("상점 처리 중 서버 오류", ex);
+        return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "상점 처리 중 오류가 발생했습니다.");
+    }
+
+    private HttpStatus resolveStatus(String message) {
+        if (message != null && (message.contains("없습니다") || message.contains("존재하지"))) {
+            return HttpStatus.NOT_FOUND;
+        }
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    private ResponseEntity<Map<String, String>> errorResponse(HttpStatus status, String message) {
+        Map<String, String> error = new HashMap<>();
+        error.put("message", message);
+        return ResponseEntity.status(status).body(error);
+    }
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/model/dto/UpdateStoreRequest.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/model/dto/UpdateStoreRequest.java
@@ -1,7 +1,6 @@
 package io.codebuddy.closetbuddy.domain.stores.model.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record UpdateStoreRequest(

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/model/dto/UpdateStoreRequest.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/model/dto/UpdateStoreRequest.java
@@ -1,6 +1,12 @@
 package io.codebuddy.closetbuddy.domain.stores.model.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public record UpdateStoreRequest(
+        @NotBlank
+        @Size(min = 1, max = 50, message = "가게 이름은 1글자 이상 50글자 이하이어야 합니다.")
         String storeName
         //추후 가게 설명, 이미지 등 추가 가능
 ) {

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/model/dto/UpsertStoreRequest.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/stores/model/dto/UpsertStoreRequest.java
@@ -3,9 +3,11 @@ package io.codebuddy.closetbuddy.domain.stores.model.dto;
 import io.codebuddy.closetbuddy.domain.sellers.model.entity.Seller;
 import io.codebuddy.closetbuddy.domain.stores.model.entity.Store;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record UpsertStoreRequest(
         @NotBlank(message = "상점 이름은 필수입니다.")
+        @Size(min = 1, max = 50, message = "상점 이름은 1글자 이상 50글자 이하여야 합니다.")
         String storeName
 ) {
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes 127

---

## 🧩 구현한 기능
- [x] 판매자, 상점, 상품 도메인 요청 DTO valid 적용및 각종 예외 발생
- [x] 발생한 예외를 각 도메인별 처리 핸들러를 구현해 서버 로그 및 응답 메시지 출력 적용
---
## 🔄 기능 흐름
1. 사용자가 허용되지 않은 값으로 요청 전송
2. 각 DTO 및 컨트롤러에서 유효성 검증 및 위반시 예외 발생
3. 핸들러에서 예외를 처리하고 예외 원인 및 내용 메시지를 서버 로그 및 응답메시지로 출력
---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 무조건 500 server error 혹은 401 인증 에러를 발생시켰던 문제를 각종 예외 발생으로 처리

---

## 🧪 테스트 방법

- [x] Postman / Swagger 테스트

---

## 🔍 리뷰 요청 포인트

- 확장성 관점에서 추후 최종 발표 때 글로벌 핸들러 적용 필요성 논의

---
