### PR TITLE
[#144] 요청 성공 응답 바디 반환값 id제거 후 json 형식으로 변경/dto 추가

### DIFF
--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductApiController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductApiController.java
@@ -1,5 +1,6 @@
 package io.codebuddy.closetbuddy.domain.catalog.products.controller;
 
+import io.codebuddy.closetbuddy.domain.catalog.web.dto.CatalogResult;
 import io.codebuddy.closetbuddy.domain.common.web.CurrentUser;
 import io.codebuddy.closetbuddy.domain.common.web.CurrentUserInfo;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductResponse;
@@ -45,7 +46,7 @@ public class ProductApiController {
     })
     @PostMapping("/stores/{storeId}/products")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<Long> create(
+    public ResponseEntity<CatalogResult<Void>> create(
             @CurrentUser CurrentUserInfo currentUser,
             @PathVariable Long storeId,
             @RequestBody @Valid ProductCreateRequest request
@@ -55,8 +56,9 @@ public class ProductApiController {
             throw new IllegalStateException("유효하지 않는 상점 ID입니다.");
         }
 
-        Long productId = productService.createProduct(Long.parseLong(currentUser.userId()), storeId, request);
-        return ResponseEntity.ok(productId);
+        productService.createProduct(Long.parseLong(currentUser.userId()), storeId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CatalogResult.messageOnly("상품 등록이 완료되었습니다."));
     }
 
     //상품 상세조회(단건)
@@ -135,7 +137,7 @@ public class ProductApiController {
             )
     })
     @PutMapping("products/{productId}")
-    public ResponseEntity<ProductResponse> updateProduct(
+    public ResponseEntity<CatalogResult<Void>> updateProduct(
             @CurrentUser CurrentUserInfo currentUser,
             @PathVariable Long productId,
             @RequestBody @Valid UpdateProductRequest request
@@ -146,7 +148,7 @@ public class ProductApiController {
         }
 
         productService.updateProduct(Long.parseLong(currentUser.userId()), productId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(CatalogResult.messageOnly("상품 정보가 수정되었습니다."));
     }
 
     //상품 삭제
@@ -166,7 +168,7 @@ public class ProductApiController {
     })
     @DeleteMapping("products/{productId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public ResponseEntity<Void> deleteProduct(
+    public ResponseEntity<CatalogResult<Void>> deleteProduct(
             @CurrentUser CurrentUserInfo currentUser,
             @PathVariable Long productId
     ) {
@@ -176,7 +178,7 @@ public class ProductApiController {
         }
 
         productService.deleteProduct(Long.parseLong(currentUser.userId()), productId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(CatalogResult.messageOnly("상품이 삭제되었습니다."));
     }
 
     //전체 상품 조회

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/controller/SellerApiController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/controller/SellerApiController.java
@@ -1,6 +1,7 @@
 package io.codebuddy.closetbuddy.domain.catalog.sellers.controller;
 
 
+import io.codebuddy.closetbuddy.domain.catalog.web.dto.CatalogResult;
 import io.codebuddy.closetbuddy.domain.common.web.CurrentUser;
 import io.codebuddy.closetbuddy.domain.common.web.CurrentUserInfo;
 import io.codebuddy.closetbuddy.domain.catalog.sellers.model.dto.SellerResponse;
@@ -42,12 +43,13 @@ public class SellerApiController {
             )
     })
     @PostMapping
-    public ResponseEntity<Long> register(
+    public ResponseEntity<CatalogResult<Void>> register(
             @CurrentUser CurrentUserInfo currentUser,
             @RequestBody @Valid SellerUpsertRequest request
     ) {
-        Long sellerId = sellerService.registerSeller(Long.parseLong(currentUser.userId()), request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(sellerId);
+        sellerService.registerSeller(Long.parseLong(currentUser.userId()), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CatalogResult.messageOnly("판매자 등록이 완료되었습니다."));
     }
 
     //내 정보 조회
@@ -89,12 +91,12 @@ public class SellerApiController {
             )
     })
     @PutMapping("/me")
-    public ResponseEntity<Void> update(
+    public ResponseEntity<CatalogResult<Void>> update(
             @CurrentUser CurrentUserInfo currentUser,
             @RequestBody @Valid SellerUpsertRequest request
     ) {
         sellerService.updateSeller(Long.parseLong(currentUser.userId()), request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(CatalogResult.messageOnly("판매자 정보가 수정되었습니다."));
     }
 
     //등록 해제
@@ -113,11 +115,11 @@ public class SellerApiController {
             )
     })
     @DeleteMapping("/me")
-    public ResponseEntity<Void> unregister(
+    public ResponseEntity<CatalogResult<Void>> unregister(
             @CurrentUser CurrentUserInfo currentUser
     ) {
         sellerService.unregisterSeller(Long.parseLong(currentUser.userId()));
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(CatalogResult.messageOnly("판매자 등록이 해제되었습니다."));
     }
 
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/stores/controller/StoreApiController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/stores/controller/StoreApiController.java
@@ -1,6 +1,7 @@
 package io.codebuddy.closetbuddy.domain.catalog.stores.controller;
 
 
+import io.codebuddy.closetbuddy.domain.catalog.web.dto.CatalogResult;
 import io.codebuddy.closetbuddy.domain.common.web.CurrentUser;
 import io.codebuddy.closetbuddy.domain.common.web.CurrentUserInfo;
 import io.codebuddy.closetbuddy.domain.catalog.stores.model.dto.StoreResponse;
@@ -46,12 +47,13 @@ public class StoreApiController {
     })
     @PostMapping("/stores")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<Long> create(
+    public ResponseEntity<CatalogResult<Void>> create(
             @CurrentUser CurrentUserInfo currentUser,
             @RequestBody @Valid UpsertStoreRequest request
-            ) {
-        Long storeId = storeService.createStore(Long.parseLong(currentUser.userId()), request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(storeId);
+    ) {
+        storeService.createStore(Long.parseLong(currentUser.userId()), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CatalogResult.messageOnly("상점 등록이 완료되었습니다."));
     }
 
     //내 가게 조회(단건)
@@ -123,7 +125,7 @@ public class StoreApiController {
             )
     })
     @PutMapping("stores/{store_id}")
-    public ResponseEntity<StoreResponse> updateStore(
+    public ResponseEntity<CatalogResult<Void>> updateStore(
             @CurrentUser CurrentUserInfo currentUser,
             @PathVariable Long store_id,
             @RequestBody @Valid UpdateStoreRequest request
@@ -134,7 +136,7 @@ public class StoreApiController {
         }
 
         storeService.updateStore(Long.parseLong(currentUser.userId()), store_id, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(CatalogResult.messageOnly("가게 정보가 수정되었습니다."));
     }
 
     //내 가게 삭제(폐점)
@@ -154,7 +156,7 @@ public class StoreApiController {
     })
     @DeleteMapping("stores/{store_id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public ResponseEntity<Void> deleteStore(
+    public ResponseEntity<CatalogResult<Void>> deleteStore(
             @CurrentUser CurrentUserInfo currentUser,
             @PathVariable Long store_id
     ) {
@@ -162,6 +164,6 @@ public class StoreApiController {
             throw new IllegalArgumentException("유효하지 않은 상점 ID입니다.");
         }
         storeService.deleteStore(Long.parseLong(currentUser.userId()), store_id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(CatalogResult.messageOnly("가게가 삭제(폐점)되었습니다."));
     }
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/web/dto/CatalogResult.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/web/dto/CatalogResult.java
@@ -1,0 +1,26 @@
+package io.codebuddy.closetbuddy.domain.catalog.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CatalogResult<T> {
+    private String message;
+    private T data;
+
+    // 데이터 없이 메시지만 반환하는 경우 (등록, 수정, 삭제 성공 등)
+    public static <T> CatalogResult<T> messageOnly(String message) {
+        return new CatalogResult<>(message, null);
+    }
+
+    // 데이터와 메시지를 함께 반환하는 경우
+    public static <T> CatalogResult<T> withData(String message, T data) {
+        return new CatalogResult<>(message, data);
+    }
+
+    // 데이터만 반환하는 경우 (조회 등, 메시지가 필요 없다면 null)
+    public static <T> CatalogResult<T> dataOnly(T data) {
+        return new CatalogResult<>(null, data);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

---

## 🧩 구현한 기능
- [x] 세 도메인 내 api 응답 바디 구성

---

## 🔄 기능 흐름
1. 사용자가 api 호출로 생성, 조회, 삭제 서비스 로직 가동
2. 서버에서 처리 후 api 응답 반환
3. 결과를 응답 바디에 json 형식으로 id를 가려서 반환

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 응답 바디에 id 값이 반환되던 로직에서 응답 코드와 함께 메시지 반환

### 🗂 구조 변경

- 응답 DTO 구현

---

## 🔍 리뷰 요청 포인트

- 응답 DTO를 만듦으로서 확장성 개선되었으니 이 부분을 중점적으로 검토해주세요

---
