### PR TITLE
userService 리팩토링 결과에 따른 feign-client구현으로 판매자 권한 생성 및 판매자 객체 생성 동기통신 구현

### DIFF
--- a/main-service/build.gradle
+++ b/main-service/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     //eureka-client
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-
+    //feign-client
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     //lombok

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/exception/SellerErrorCode.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/exception/SellerErrorCode.java
@@ -12,7 +12,13 @@ public enum SellerErrorCode {
     SELLER_NOT_FOUND(HttpStatus.NOT_FOUND, "판매자 정보를 찾을 수 없습니다."),
 
     // 권한 없음 등 (403 Forbidden)
-    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "판매자 권한이 없습니다.");
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "판매자 권한이 없습니다."),
+
+    // 판매자 역할 부여 실패 (503 Service Unavailable)
+    ROLE_GRANT_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "판매자 역할 부여에 실패했습니다. 잠시 후 다시 시도해주세요."),
+
+    //판매자 역할 해제 실패(503 Service Unavailable)
+    ROLE_REVOKE_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "판매자 역할 해제에 실패했습니다. 잠시 후 다시 시도해 주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/service/SellerService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/service/SellerService.java
@@ -44,13 +44,13 @@ public class SellerService {
         // user-service에 판매자 역할 부여 요청(동기 요청)
         try {
             log.info("user-service에 판매자 역할 부여 요청 - memberId: {}", loginMemberId);
-            userServiceClient.grantSellerRole();
+            userServiceClient.grantSellerRole(loginMemberId);
             log.info("user-service 판매자 역할 부여 완료 - memberId: {}", loginMemberId);
         } catch (SellerException e) {
             log.error("user-service 판매자 역할 부여 실패 - memberId: {}, errorCode: {}", loginMemberId, e.getErrorCode());
             throw e;
         } catch (Exception e) {
-            log.error("user-service 판매자 역할 부여 실패 - memberId: {}, error: {}",  loginMemberId, e.getMessage());
+            log.error("user-service 판매자 역할 부여 실패 - memberId: {}, error: {}", loginMemberId, e.getMessage());
             throw new SellerException(SellerErrorCode.ROLE_GRANT_FAILED);
         }
 
@@ -68,7 +68,7 @@ public class SellerService {
 
     // 판매자 정보 수정(Update)
     @Transactional
-    public  void updateSeller(Long loginMemberId, SellerUpsertRequest request) {
+    public void updateSeller(Long loginMemberId, SellerUpsertRequest request) {
         // 판매자 정보를 우선 불러오기
         Seller seller = sellerJpaRepository.findByMemberId(loginMemberId)
                 .orElseThrow(() -> new SellerException(SellerErrorCode.UNAUTHORIZED_ACCESS));
@@ -90,7 +90,7 @@ public class SellerService {
         // 2. user-service에 판매자 역할 해제 요청 (동기 호출)
         try {
             log.info("user-service에 판매자 역할 해제 요청 - memberId: {}", loginMemberId);
-            userServiceClient.revokeSellerRole();
+            userServiceClient.revokeSellerRole(loginMemberId);
             log.info("user-service 판매자 역할 해제 완료 - memberId: {}", loginMemberId);
         } catch (SellerException e) {
             // FeignErrorDecoder에서 변환된 SellerException은 그대로 전파

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/service/SellerService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/service/SellerService.java
@@ -8,12 +8,15 @@ import io.codebuddy.closetbuddy.domain.catalog.sellers.model.entity.Seller;
 import io.codebuddy.closetbuddy.domain.catalog.sellers.repository.SellerJpaRepository;
 import io.codebuddy.closetbuddy.domain.catalog.stores.model.entity.Store;
 import io.codebuddy.closetbuddy.domain.catalog.stores.repository.StoreJpaRepository;
+import io.codebuddy.closetbuddy.domain.common.feign.UserServiceClient;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SellerService {
@@ -21,23 +24,40 @@ public class SellerService {
     private final SellerJpaRepository sellerJpaRepository;
 
     private final StoreJpaRepository storeJpaRepository;
+    private final UserServiceClient userServiceClient;
 
-    //판매자 등록(Create)
+    // 판매자 등록(Create)
     @Transactional
     public Long registerSeller(Long loginMemberId, SellerUpsertRequest request) {
         sellerJpaRepository.findByMemberId(loginMemberId)
                 .ifPresent(seller -> {
                     throw new SellerException(SellerErrorCode.ALREADY_REGISTERED);
                 });
-
+        // seller Entity 생성
         Seller seller = Seller.builder()
                 .memberId(loginMemberId)
                 .sellerName(request.sellerName())
                 .build();
 
-        return sellerJpaRepository.saveAndFlush(seller).getSellerId();
+        Long sellerId = sellerJpaRepository.saveAndFlush(seller).getSellerId();
+
+        // user-service에 판매자 역할 부여 요청(동기 요청)
+        try {
+            log.info("user-service에 판매자 역할 부여 요청 - memberId: {}", loginMemberId);
+            userServiceClient.grantSellerRole();
+            log.info("user-service 판매자 역할 부여 완료 - memberId: {}", loginMemberId);
+        } catch (SellerException e) {
+            log.error("user-service 판매자 역할 부여 실패 - memberId: {}, errorCode: {}", loginMemberId, e.getErrorCode());
+            throw e;
+        } catch (Exception e) {
+            log.error("user-service 판매자 역할 부여 실패 - memberId: {}, error: {}",  loginMemberId, e.getMessage());
+            throw new SellerException(SellerErrorCode.ROLE_GRANT_FAILED);
+        }
+
+        return sellerId;
     }
-    //판매자 정보 조회 (Read)
+
+    // 판매자 정보 조회 (Read)
     @Transactional(readOnly = true)
     public SellerResponse getSellerInfo(Long loginMemberId) {
         Seller seller = sellerJpaRepository.findByMemberId(loginMemberId)
@@ -46,24 +66,39 @@ public class SellerService {
         return SellerResponse.from(seller);
     }
 
-    //판매자 정보 수정(Update)
+    // 판매자 정보 수정(Update)
     @Transactional
     public  void updateSeller(Long loginMemberId, SellerUpsertRequest request) {
-        //판매자 정보를 우선 불러오기
+        // 판매자 정보를 우선 불러오기
         Seller seller = sellerJpaRepository.findByMemberId(loginMemberId)
                 .orElseThrow(() -> new SellerException(SellerErrorCode.UNAUTHORIZED_ACCESS));
 
         seller.update(request.sellerName());
     }
 
-    //판매자 삭제(판매자 등록 해제, Delete)
+    // 판매자 삭제(판매자 등록 해제, Delete)
     @Transactional
     public void unregisterSeller(Long loginMemberId) {
         Seller seller = sellerJpaRepository.findByMemberId(loginMemberId)
-                .orElseThrow( () -> new SellerException(SellerErrorCode.UNAUTHORIZED_ACCESS));
+                .orElseThrow(() -> new SellerException(SellerErrorCode.UNAUTHORIZED_ACCESS));
 
+        // 1. 스토어 및 판매자 삭제
         List<Store> stores = storeJpaRepository.findAllBySeller(seller);
         storeJpaRepository.deleteAll(stores);
         sellerJpaRepository.delete(seller);
+
+        // 2. user-service에 판매자 역할 해제 요청 (동기 호출)
+        try {
+            log.info("user-service에 판매자 역할 해제 요청 - memberId: {}", loginMemberId);
+            userServiceClient.revokeSellerRole();
+            log.info("user-service 판매자 역할 해제 완료 - memberId: {}", loginMemberId);
+        } catch (SellerException e) {
+            // FeignErrorDecoder에서 변환된 SellerException은 그대로 전파
+            log.error("user-service 판매자 역할 해제 실패 - memberId: {}, errorCode: {}", loginMemberId, e.getErrorCode());
+            throw e;
+        } catch (Exception e) {
+            log.error("user-service 판매자 역할 해제 실패 - memberId: {}, error: {}", loginMemberId, e.getMessage());
+            throw new SellerException(SellerErrorCode.ROLE_REVOKE_FAILED);
+        }
     }
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/FeignConfig.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/FeignConfig.java
@@ -2,11 +2,18 @@ package io.codebuddy.closetbuddy.domain.common.feign;
 
 
 import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import feign.codec.ErrorDecoder;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+/**
+ * Feign Client 설정
+ */
 @Slf4j
 @Configuration
 public class FeignConfig {
@@ -16,8 +23,30 @@ public class FeignConfig {
         return new FeignErrorDecoder();
     }
 
+    /**
+     * 호출한 HTTP 요청의 Authorization 헤더를 feign 호출 시 그대로 전달
+     * 결과 : Gateway에서 주입한 인증 정보(X-USER-ID, X-USER-ROLE)가 그대로 user-service에서 전달
+     */
     @Bean
     public RequestInterceptor authHeaderInterceptor() {
+        return (RequestTemplate template) -> {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
 
+            if ( attributes != null) {
+                HttpServletRequest request = attributes.getRequest();
+                String authorization = request.getHeader("Authorization");
+
+                log.debug("Feign RequestInterceptor - Authorization 헤더 : {}",
+                        authorization != null ? "존재 (길이: " + authorization.length() + ")" : "없음");
+
+                if (authorization != null) {
+                    template.header("Authorization", authorization);
+                } else {
+                    log.warn("Feign 호출 시 Authorization Header가 없습니다. 요청 URI : {}", request.getRequestURI());
+                }
+            }else {
+                log.warn("Feign RequestInterceptor - RequestAttributes가 null입니다. RequestContextHolder에서 요청 정보를 가져올 수 없습니다.");
+            }
+        };
     }
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/FeignConfig.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/FeignConfig.java
@@ -1,0 +1,23 @@
+package io.codebuddy.closetbuddy.domain.common.feign;
+
+
+import feign.RequestInterceptor;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new FeignErrorDecoder();
+    }
+
+    @Bean
+    public RequestInterceptor authHeaderInterceptor() {
+
+    }
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/FeignErrorDecoder.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/FeignErrorDecoder.java
@@ -1,0 +1,34 @@
+package io.codebuddy.closetbuddy.domain.common.feign;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import io.codebuddy.closetbuddy.domain.catalog.sellers.exception.SellerErrorCode;
+import io.codebuddy.closetbuddy.domain.catalog.sellers.exception.SellerException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder defaultErrorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        log.error("feign 호출 에러 - method: {}, status: {}, reason: {}",
+                methodKey, response.status(), response.reason());
+
+        // 판매자 역할 관련 API 호출 실패 시 적절한 SellerErrorCode로 매핑
+        return switch (response.status()) {
+            case 400 -> // Bad Request - 잘못된 요청
+                new SellerException(SellerErrorCode.ROLE_GRANT_FAILED);
+            case 401, 403 -> // Unauthorized, Forbidden - 인증/인가 실패(권한 없음)
+                new SellerException(SellerErrorCode.UNAUTHORIZED_ACCESS);
+            case 404 -> //Not Found - 회원을 찾을 수 없음
+                new SellerException(SellerErrorCode.SELLER_NOT_FOUND);
+            case 409 -> //Conflict - 이미 판매자로 등록됨
+                new SellerException(SellerErrorCode.ALREADY_REGISTERED);
+            case 500, 502, 503, 504 -> // ServerError- 서비스 불가
+                new SellerException(SellerErrorCode.ROLE_GRANT_FAILED);
+            default ->  defaultErrorDecoder.decode(methodKey, response);
+        };
+    }
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/UserServiceClient.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/UserServiceClient.java
@@ -1,0 +1,19 @@
+package io.codebuddy.closetbuddy.domain.common.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "user-service")//판매자 등록 요청시 헤더 자동전달
+public interface UserServiceClient {
+
+
+    @PostMapping("/api/v1/members/me/seller")
+    ResponseEntity<Void>grantSellerRole;
+
+
+    @DeleteMapping("/api/v1/members/me/seller")
+    ResponseEntity<Void>revokeSellerRole;
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/UserServiceClient.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/UserServiceClient.java
@@ -6,14 +6,30 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
-@FeignClient(name = "user-service")//판매자 등록 요청시 헤더 자동전달
+/**
+ * user-service와 통신하기 위한 Feign Client
+ * Eureka를 통해 서비스 디스커버리 사용
+ * 내부 API (MemberInternalController) 호출
+ * Gateway를 거치지 않는 서비스 간 직접 통신
+ */
+@FeignClient(name = "user-service")
 public interface UserServiceClient {
 
+    /**
+     * 판매자 역할 부여 요청
+     * 내부 API를 통해 memberId로 직접 역할 부여
+     * 
+     * @param memberId 대상 회원 ID
+     */
+    @PostMapping("/internal/members/{memberId}/seller")
+    ResponseEntity<Void> grantSellerRole(@PathVariable("memberId") Long memberId);
 
-    @PostMapping("/api/v1/members/me/seller")
-    ResponseEntity<Void>grantSellerRole;
-
-
-    @DeleteMapping("/api/v1/members/me/seller")
-    ResponseEntity<Void>revokeSellerRole;
+    /**
+     * 판매자 역할 해제 요청
+     * 내부 API를 통해 memberId로 직접 역할 해제
+     * 
+     * @param memberId 대상 회원 ID
+     */
+    @DeleteMapping("/internal/members/{memberId}/seller")
+    ResponseEntity<Void> revokeSellerRole(@PathVariable("memberId") Long memberId);
 }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/SecurityConfig.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package io.codebuddy.userservice.domain.common.config;
 
-
 import io.codebuddy.userservice.domain.auth.token.security.handler.CustomAuthenticationEntryPoint;
 import io.codebuddy.userservice.domain.auth.token.security.filter.JwtExceptionFilter;
 import io.codebuddy.userservice.domain.auth.token.security.filter.JwtAuthenticationFilter;
@@ -24,98 +23,103 @@ import org.springframework.web.cors.CorsUtils;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final OAuth2SuccessHandler oAuth2SuccessHandler;
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+        private final OAuth2SuccessHandler oAuth2SuccessHandler;
+        private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+        private final JwtExceptionFilter jwtExceptionFilter; // [추가]
 
-    private final JwtExceptionFilter jwtExceptionFilter; // [추가]
+        private final MemberAuthSuccessHandler memberAuthSuccessHandler;
+        private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
 
-    private final MemberAuthSuccessHandler memberAuthSuccessHandler;
-    private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
+        // [추가]
+        private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+        private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    // [추가]
-    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
-    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+        // 1. SecurityFilterChain 빈으로 OAuth2 로그인과 JWT 필터 등록.
 
-    //1. SecurityFilterChain 빈으로 OAuth2 로그인과 JWT 필터 등록.
+        /*
+         * Spring Security 설정을 통해 기존 인증 방식을 비활성화하고 API 엔드포인트에 대해 JWT 기반의 상태
+         * 비저장 보안을 사용하는 OAuth2 로그인을 설정
+         */
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
-    /* Spring Security 설정을 통해 기존 인증 방식을 비활성화하고 API 엔드포인트에 대해 JWT 기반의 상태
-    비저장 보안을 사용하는 OAuth2 로그인을 설정*/
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+                return http
+                                // .securityMatcher("/oauth2/**","/login/oauth2/**", "/api/**","/api/v1/**")
+                                .authorizeHttpRequests((request) -> request
+                                                .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                                                .requestMatchers("/login-success").permitAll()
+                                                .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+                                                .requestMatchers("/api/v1/auth/**").permitAll()
+                                                .requestMatchers("/api/v1/authc/**").permitAll()
+                                                // 내부 서비스 간 통신용 API - 인증 불필요
+                                                .requestMatchers("/internal/**").permitAll()
 
+                                                .requestMatchers("/api/v1/members/**")
+                                                .hasAnyAuthority("MEMBER", "SELLER")
+                                                .requestMatchers("/api/v1/payments/**")
+                                                .hasAnyAuthority("MEMBER", "SELLER")
+                                                .requestMatchers("/api/v1/account/**")
+                                                .hasAnyAuthority("MEMBER", "SELLER")
+                                                .requestMatchers("/api/v1/catalog/sellers/**").hasAnyAuthority("SELLER")
+                                                .requestMatchers("/api/v1/catalog/stores/**").hasAnyAuthority("SELLER")
+                                                .requestMatchers("/api/v1/catalog/products/**").hasAnyAuthority("GUEST")
+                                                .requestMatchers("/api/v1/orders").hasAnyAuthority("MEMBER")
+                                                .requestMatchers("/api/v1/carts").hasAnyAuthority("MEMBER")
+                                                .requestMatchers("/api/v1/auth/refresh")
+                                                .hasAnyAuthority("MEMBER", "SELLER")
+                                                .anyRequest().authenticated() // 그외에는 인증 필요
+                                )
+                                .sessionManagement(session -> session
+                                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                                .csrf(csrf -> csrf.disable())
+                                .cors(cors -> cors.disable())
+                                .httpBasic(httpB -> httpB.disable())
 
+                                // 로그인
+                                .formLogin(form -> form
+                                                .loginProcessingUrl("/api/v1/auth/login")
+                                                .successHandler(memberAuthSuccessHandler)
+                                                .failureHandler(customAuthenticationFailureHandler)
+                                                .usernameParameter("memberId")
+                                                .passwordParameter("password")
+                                                .permitAll())
+                                /*
+                                 * .logout(logout -> logout
+                                 * .logoutUrl("/api/v1/auth/logout") // 로그아웃 처리 URL
+                                 * .logoutSuccessUrl("/api/v1/auth/loginForm?logout=1") // 로그아웃 성공 후 이동페이지
+                                 * .deleteCookies("JSESSIONID") // 로그아웃 후 쿠키 삭제
+                                 * .addLogoutHandler(jwtLogoutHandler)
+                                 * .logoutSuccessHandler(apiLogoutSuccessHandler)
+                                 * )
+                                 */
 
+                                // 인증/인가 예외 처리
+                                .exceptionHandling(handling -> handling
+                                                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                                                .accessDeniedHandler(customAccessDeniedHandler))
 
-        return http
-//                .securityMatcher("/oauth2/**","/login/oauth2/**", "/api/**","/api/v1/**")
-                .authorizeHttpRequests((request) -> request
-                        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                        .requestMatchers("/login-success").permitAll()
-                        .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
-                        .requestMatchers("/api/v1/auth/**").permitAll()
-                        .requestMatchers("/api/v1/authc/**").permitAll()
-                        .requestMatchers("/api/v1/payments/**").hasAnyAuthority("MEMBER", "SELLER")
-                        .requestMatchers("/api/v1/account/**").hasAnyAuthority("MEMBER", "SELLER")
-                        .requestMatchers("/api/v1/catalog/sellers/**").hasAnyAuthority("SELLER")
-                        .requestMatchers("/api/v1/catalog/stores/**").hasAnyAuthority("SELLER")
-                        .requestMatchers("/api/v1/catalog/products/**").hasAnyAuthority("GUEST")
-                        .requestMatchers("/api/v1/orders").hasAnyAuthority("MEMBER")
-                        .requestMatchers("/api/v1/carts").hasAnyAuthority("MEMBER")
-                        .requestMatchers("/api/v1/auth/refresh").hasAnyAuthority("MEMBER","SELLER")
-                        .anyRequest().authenticated() //그외에는 인증 필요
-                )
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .csrf(csrf -> csrf.disable())
-                .cors( cors -> cors.disable())
-                .httpBasic(httpB -> httpB.disable())
+                                // OAuth2 로그인 활성화
+                                .oauth2Login(oauth2 -> oauth2 // formLogin 후 위치 유지
+                                                .successHandler(oAuth2SuccessHandler)
+                                                .failureUrl("/api/v1/auth/error") // 백엔드 경로로 변경
+                                )
 
-                //로그인
-                .formLogin(form -> form
-                        .loginProcessingUrl("/api/v1/auth/login")
-                        .successHandler(memberAuthSuccessHandler)
-                        .failureHandler(customAuthenticationFailureHandler)
-                        .usernameParameter("memberId")
-                        .passwordParameter("password")
-                        .permitAll()
-                )
-/*
-                .logout(logout -> logout
-                        .logoutUrl("/api/v1/auth/logout") // 로그아웃 처리 URL
-                        .logoutSuccessUrl("/api/v1/auth/loginForm?logout=1") // 로그아웃 성공 후 이동페이지
-                        .deleteCookies("JSESSIONID") // 로그아웃 후 쿠키 삭제
-                        .addLogoutHandler(jwtLogoutHandler)
-                        .logoutSuccessHandler(apiLogoutSuccessHandler)
-                )
-*/
+                                .exceptionHandling(handling -> handling
+                                                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                                                .accessDeniedHandler(customAccessDeniedHandler))
 
-                // 인증/인가 예외 처리
-                .exceptionHandling(handling -> handling
-                        .authenticationEntryPoint(customAuthenticationEntryPoint)
-                        .accessDeniedHandler(customAccessDeniedHandler)
-                )
+                                // 필터 순서: JwtExceptionFilter -> JwtAuthenticationFilter ->
+                                // UsernamePasswordAuthenticationFilter
+                                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class) // [추가]
 
-                //OAuth2 로그인 활성화
-                .oauth2Login(oauth2 -> oauth2  // formLogin 후 위치 유지
-                        .successHandler(oAuth2SuccessHandler)
-                        .failureUrl("/api/v1/auth/error")  // 백엔드 경로로 변경
-                )
+                                .build();// 필터 체인 빌드
 
-                .exceptionHandling(handling -> handling
-                        .authenticationEntryPoint(customAuthenticationEntryPoint)
-                        .accessDeniedHandler(customAccessDeniedHandler)
-                )
+        }
 
-                // 필터 순서: JwtExceptionFilter -> JwtAuthenticationFilter -> UsernamePasswordAuthenticationFilter
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class) // [추가]
-
-                .build();// 필터 체인 빌드
-
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder(){
-        return new BCryptPasswordEncoder();
-    }
+        @Bean
+        public PasswordEncoder passwordEncoder() {
+                return new BCryptPasswordEncoder();
+        }
 }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberController.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberController.java
@@ -40,13 +40,23 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    //판매자 권한 변경
+    // 판매자 권한 부여
     @PostMapping("/me/seller")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Long> registerSeller(
             @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails principal) {
 
         memberCommandService.registerSeller(principal.getId());
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 판매자 등록 해제 (역할 해제)
+    @DeleteMapping("/me/seller")
+    public ResponseEntity<Void> unregisterSeller(
+            @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails principal) {
+
+        memberCommandService.revokeSeller(principal.getId());
 
         return ResponseEntity.ok().build();
     }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberInternalController.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberInternalController.java
@@ -1,0 +1,47 @@
+package io.codebuddy.userservice.domain.member.controller;
+
+import io.codebuddy.userservice.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 내부 서비스 간 통신용 API Controller
+ * Gateway를 거치지 않는 서비스 간 직접 통신에 사용
+ * Security에서 인증 없이 접근 가능하도록 설정됨
+ */
+@Slf4j
+@RestController
+@RequestMapping("/internal/members")
+@RequiredArgsConstructor
+public class MemberInternalController {
+
+    private final MemberService memberService;
+
+    /**
+     * 판매자 역할 부여 (main-service에서 호출)
+     * 
+     * @param memberId 대상 회원 ID
+     */
+    @PostMapping("/{memberId}/seller")
+    public ResponseEntity<Void> grantSellerRole(@PathVariable Long memberId) {
+        log.info("내부 API - 판매자 역할 부여 요청 - memberId: {}", memberId);
+        memberService.registerSeller(memberId);
+        log.info("내부 API - 판매자 역할 부여 완료 - memberId: {}", memberId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 판매자 역할 해제 (main-service에서 호출)
+     * 
+     * @param memberId 대상 회원 ID
+     */
+    @DeleteMapping("/{memberId}/seller")
+    public ResponseEntity<Void> revokeSellerRole(@PathVariable Long memberId) {
+        log.info("내부 API - 판매자 역할 해제 요청 - memberId: {}", memberId);
+        memberService.revokeSeller(memberId);
+        log.info("내부 API - 판매자 역할 해제 완료 - memberId: {}", memberId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/member/service/MemberService.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/member/service/MemberService.java
@@ -71,7 +71,24 @@ public class MemberService {
 
         // 3. Member의 권한 변경
         member.setRole(Role.SELLER);
+    }
 
+    /**
+     * 판매자 역할 해제
+     * SELLER 권한을 USER 권한으로 변경
+     */
+    public void revokeSeller(Long memberId) {
+        // 1. 회원 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        // 2. 판매자 권한인지 체크
+        if (member.getRole() != Role.SELLER) {
+            throw new IllegalStateException("판매자 권한이 아닙니다.");
+        }
+
+        // 3. Member의 권한을 MEMBER로 변경
+        member.setRole(Role.MEMBER);
     }
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #168

---

## 🧩 구현한 기능
- [x] 각 서비스에 각각 존재하던 판매자 객체 생성 로직과 판매자 역할 부여 api를 동기방식으로 처리하기 위해 feign-client를 이용해 인터페이스 구현
- [x] 내부 api 구현을 통해 보안성 확보 및 외부 호출 차단
- [x] 판매자 객체 생성 및 삭제/ 권한 변경 구현

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 판매자 등록 요청
2. 판매자 객체 생성 -> 판매자 권한 부여
3. 요청 응답 반환
4. 판매자 등록 해제 동일

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 api를 각각 호출하던 방식에서 동기방식 호출로 변경
- 내부 api 구현

### 🗂 구조 변경
- main-service내 feign 패키지 추가
- feign client 구현을 및 각 서비스 통신을 위해 feign config 클래스 추가

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman 테스트 완료

---

## 🚀 예상 추가 작업
-  성능 개선
-  예외 처리 보완
-  테스트 코드 보강
