### PR TITLE
[#174] 회원 가입 시 OpenFeign을 이용한 계좌 생성 구현

### DIFF
--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/controller/InternalAccountController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/controller/InternalAccountController.java
@@ -1,0 +1,25 @@
+package io.codebuddy.closetbuddy.domain.pay.accounts.controller;
+
+import io.codebuddy.closetbuddy.domain.pay.accounts.model.entity.Account;
+import io.codebuddy.closetbuddy.domain.pay.accounts.model.vo.AccountCreateRequest;
+import io.codebuddy.closetbuddy.domain.pay.accounts.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/accounts")
+@RequiredArgsConstructor
+public class InternalAccountController {
+
+    private final AccountService accountService;
+
+    @PostMapping
+    public ResponseEntity<Void> createAccount(@RequestBody AccountCreateRequest request) {
+        accountService.createAccount(request.memberId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/model/entity/Account.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/model/entity/Account.java
@@ -17,17 +17,16 @@ public class Account {
     @Column(name = "account_id")
     private Long accountId;
 
-    @Column(name = "balance")
-    private Long balance;
+    @Column(name = "balance", nullable = false)
+    private Long balance=0L;
 
     @Column(name = "member_id", nullable = false, unique = true)
     private Long memberId;
 
     @Builder
-    public Account(Long accountId,Long balance,Long memberId){
-        this.accountId=accountId;
-        this.balance=0L;
+    public Account(Long memberId, Long balance){
         this.memberId=memberId;
+        this.balance = (balance != null) ? balance : 0L;
     }
     public static Account createAccount(Long memberId) {
         return Account.builder()

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/model/vo/AccountCreateRequest.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/model/vo/AccountCreateRequest.java
@@ -1,0 +1,6 @@
+package io.codebuddy.closetbuddy.domain.pay.accounts.model.vo;
+
+public record AccountCreateRequest(
+        Long memberId
+) {
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/service/AccountService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/service/AccountService.java
@@ -19,4 +19,5 @@ public interface AccountService {
 
     AccountHistoryResponse refund(Long memberId, Long historyId, String reason);
 
+    void createAccount(Long memberId);
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/service/AccountServiceImpl.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/pay/accounts/service/AccountServiceImpl.java
@@ -246,4 +246,10 @@ public class AccountServiceImpl implements AccountService{
         return AccountMapper.toHistoryResponse(history);
     }
 
+    @Override
+    public void createAccount(Long memberId) {
+        Account account= Account.createAccount(memberId);
+        accountRepository.save(account);
+
+    }
 }

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+    //openFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 dependencyManagement {

--- a/user-service/src/main/java/io/codebuddy/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/UserServiceApplication.java
@@ -3,7 +3,9 @@ package io.codebuddy.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class UserServiceApplication {

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/auth/form/service/SignService.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/auth/form/service/SignService.java
@@ -39,13 +39,9 @@ public class SignService {
         try {
             mainServiceClient.createAccount(new AccountCreateRequest(loginmember.getId()));
         } catch (Exception e) {
-            // [디버깅용] 에러 로그를 출력해야 main-service가 무슨 말을 했는지 알 수 있음
-            e.printStackTrace();
-
-            // 만약 FeignException이라면 e.contentUTF8() 등을 통해
-            // main-service가 보낸 구체적인 에러 메시지(500, Null constraint violation 등)를 볼 수 있어.
 
             throw new RuntimeException("계좌 생성 실패: " + e.getMessage());
+
         }
 
 

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/auth/form/service/SignService.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/auth/form/service/SignService.java
@@ -1,6 +1,8 @@
 package io.codebuddy.userservice.domain.auth.form.service;
 
 
+import io.codebuddy.userservice.domain.common.feign.client.MainServiceClient;
+import io.codebuddy.userservice.domain.common.feign.dto.AccountCreateRequest;
 import io.codebuddy.userservice.domain.member.dto.Role;
 import io.codebuddy.userservice.domain.auth.token.dto.SignReqDTO;
 import io.codebuddy.userservice.domain.member.domain.Member;
@@ -8,12 +10,15 @@ import io.codebuddy.userservice.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class SignService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MainServiceClient mainServiceClient;
 
 
     public Member create(SignReqDTO signReqDTO) {
@@ -28,8 +33,23 @@ public class SignService {
                 .role(Role.MEMBER)
                 .build();
 
+        Member savedMember = memberRepository.save(loginmember);
 
-        return memberRepository.save(loginmember);
+        // Main-Service로 계좌 생성 요청 (동기 통신)
+        try {
+            mainServiceClient.createAccount(new AccountCreateRequest(loginmember.getId()));
+        } catch (Exception e) {
+            // [디버깅용] 에러 로그를 출력해야 main-service가 무슨 말을 했는지 알 수 있음
+            e.printStackTrace();
+
+            // 만약 FeignException이라면 e.contentUTF8() 등을 통해
+            // main-service가 보낸 구체적인 에러 메시지(500, Null constraint violation 등)를 볼 수 있어.
+
+            throw new RuntimeException("계좌 생성 실패: " + e.getMessage());
+        }
+
+
+        return savedMember;
     }
 
 

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/auth/oauth/service/OauthService.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/auth/oauth/service/OauthService.java
@@ -60,7 +60,7 @@ public class OauthService extends DefaultOAuth2UserService {
         try {
             mainServiceClient.createAccount(new AccountCreateRequest(member.getId()));
         } catch (Exception e) {
-            throw new OAuth2AuthenticationException("계좌 생성 실패");
+            throw new OAuth2AuthenticationException("계좌 생성 실패: "+ e.getMessage());
         }
 
         return memberDetails;

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/auth/oauth/service/OauthService.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/auth/oauth/service/OauthService.java
@@ -1,5 +1,7 @@
 package io.codebuddy.userservice.domain.auth.oauth.service;
 
+import io.codebuddy.userservice.domain.common.feign.client.MainServiceClient;
+import io.codebuddy.userservice.domain.common.feign.dto.AccountCreateRequest;
 import io.codebuddy.userservice.domain.member.dto.Role;
 import io.codebuddy.userservice.domain.member.domain.Member;
 import io.codebuddy.userservice.domain.member.repository.MemberRepository;
@@ -23,6 +25,7 @@ import java.util.Optional;
 public class OauthService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
+    private final MainServiceClient mainServiceClient;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -50,6 +53,14 @@ public class OauthService extends DefaultOAuth2UserService {
                                 .role(Role.MEMBER)
                                 .build()
                 ));
+
+        // Main-Service로 계좌 생성 요청 (동기 통신)
+        try {
+            mainServiceClient.createAccount(new AccountCreateRequest(member.getId()));
+        } catch (Exception e) {
+            throw new OAuth2AuthenticationException("계좌 생성 실패");
+        }
+
         return new MemberDetails(member, oAuth2User.getAttributes());
     }
 

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/auth/oauth/service/OauthService.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/auth/oauth/service/OauthService.java
@@ -54,6 +54,8 @@ public class OauthService extends DefaultOAuth2UserService {
                                 .build()
                 ));
 
+        MemberDetails memberDetails = new MemberDetails(member, oAuth2User.getAttributes());
+
         // Main-Service로 계좌 생성 요청 (동기 통신)
         try {
             mainServiceClient.createAccount(new AccountCreateRequest(member.getId()));
@@ -61,7 +63,7 @@ public class OauthService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException("계좌 생성 실패");
         }
 
-        return new MemberDetails(member, oAuth2User.getAttributes());
+        return memberDetails;
     }
 
     public Optional<Member> findById(Long id) {

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/feign/client/MainServiceClient.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/feign/client/MainServiceClient.java
@@ -1,0 +1,14 @@
+package io.codebuddy.userservice.domain.common.feign.client;
+
+import io.codebuddy.userservice.domain.common.feign.dto.AccountCreateRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "closetBuddy")
+public interface MainServiceClient {
+
+    // 계좌 생성 요청 API
+    @PostMapping("/internal/accounts")
+    void createAccount(@RequestBody AccountCreateRequest request);
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/feign/dto/AccountCreateRequest.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/feign/dto/AccountCreateRequest.java
@@ -1,0 +1,6 @@
+package io.codebuddy.userservice.domain.common.feign.dto;
+
+public record AccountCreateRequest(
+        Long memberId
+) {
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #174 

---

## 🧩 구현한 기능
- [x] user-service의 openFeign 설정
- [x] user-service의 회원 가입 서비스(폼 로그인 + oAuth)에서 계좌 생성 api 호출
- [x] account-service에서 호출된 api로 계좌 생성

> **회원 가입 시 FeignClient를 이용하여 계좌 생성 로직을 구현하였습니다.** 
> **회원 가입이 진행되면 member 테이블에 회원 가입 정보가 저장되고, account 테이블에 해당 memberId를 가진 row가 생성됩니다.**
> **폼 로그인 방식과 oauth 방식 모두에서 동작합니다.**

---

## 🔄 기능 흐름
1. 사용자가 회원 가입 요청
2. 서버에서 회원 가입 및 계좌 생성 처리
3. member 테이블에 회원 가입 정보 저장 및 account 테이블에 해당 memberId를 가진 계좌 생성

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 회원가입 서비스에서 리턴될 때 member 테이블에 저장되던 부분이 미리 저장되는 방식으로 변경 ( 결과 동일 ) 


### 🗂 구조 변경
- 패키지 구조 변경 여부
    - user-service의 common 패키지 아래에 `feign` 추가 
- 새로 추가된 클래스
    - main-service의 FeignClient 호출을 위한 `InternalAccountController` 추가
    - user-service에 새로 추가된 `feign` 패키지 아래에 FeignClient 사용을 위한 `MainServiceClient`와 DTO 추가

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman 테스트
- [x] 기존 로직이 잘 작동되는 지 확인하기 위해 예치금과 관련한 서비스 전체를 postman으로 테스트하였습니다. 

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한지 확인 부탁드립니다.
- 예외 처리 방식에 대한 의견을 주시면 좋겠습니다.
- 성능 또는 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] 예외 처리 보완
