### PR TITLE
[#173] 각 서비스의 예외 발행 및 에외 처리 핸들러 응답을 gateway의 토큰 검증 과정에서 덮어쓰는 버그 해결

### DIFF
--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
@@ -35,17 +35,18 @@ public class AuthHeaderInjectFilter extends OncePerRequestFilter {
             try {
                 verified = tokenVerifier.verify(authHeader);
             } catch (HttpClientErrorException e) {
-                // 1. User-Service에서 받은 상태 코드를 그대로 설정 (주로 401)
+                // User-Service에서 받은 상태 코드를 그대로 설정
                 response.setStatus(e.getStatusCode().value());
 
-                // 2. 응답 타입 설정 (JSON)
+                // 응답 타입 설정 (JSON)
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 response.setCharacterEncoding("UTF-8");
-                // 3. User-Service가 보낸 에러 바디(JSON)를 그대로 쓰기
+                // User-Service가 보낸 에러 바디(JSON)를 그대로 쓰기
                 response.getWriter().write(e.getResponseBodyAsString());
 
                 return; // 필터 체인 중단
-            } catch (Exception ex) {
+            }
+            catch (Exception ex) {
                 // 그 외 예상치 못한 에러 처리
                 ex.printStackTrace();
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
@@ -7,11 +7,12 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-
 
 //헤더에 X-User_id, X-User-Role 주입
 @Component
@@ -25,28 +26,33 @@ public class AuthHeaderInjectFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
         String authHeader = request.getHeader("Authorization");
 
         if (authHeader != null) {
             VerifiedUser verified;
             try {
                 verified = tokenVerifier.verify(authHeader);
+            } catch (HttpClientErrorException e) {
+                // 1. User-Service에서 받은 상태 코드를 그대로 설정 (주로 401)
+                response.setStatus(e.getStatusCode().value());
+
+                // 2. 응답 타입 설정 (JSON)
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                response.setCharacterEncoding("UTF-8");
+                // 3. User-Service가 보낸 에러 바디(JSON)를 그대로 쓰기
+                response.getWriter().write(e.getResponseBodyAsString());
+
+                return; // 필터 체인 중단
             } catch (Exception ex) {
+                // 그 외 예상치 못한 에러 처리
                 ex.printStackTrace();
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             }
-            //헤더 주입 -> yml 파일로 빼서 주입, 관례상 전체 대문자(추가적인 X헤더 에 많은 주입 재고)
-            MutableHttpServletRequest wrapped = new MutableHttpServletRequest(request);
-            wrapped.putHeader("X-USER-ID", verified.userId());
-            wrapped.putHeader("X-USER-ROLE", verified.role());
 
-            filterChain.doFilter(wrapped, response);
-            return;
+            filterChain.doFilter(request, response);
         }
-
-        filterChain.doFilter(request, response);
     }
 }

--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
@@ -2,7 +2,6 @@ package io.codebuddy.gatewayservice.filter;
 
 import io.codebuddy.gatewayservice.security.TokenVerifier;
 import io.codebuddy.gatewayservice.security.VerifiedUser;
-import io.codebuddy.gatewayservice.web.MutableHttpServletRequest;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
@@ -53,7 +53,7 @@ public class AuthHeaderInjectFilter extends OncePerRequestFilter {
                 return;
             }
 
-            filterChain.doFilter(request, response);
         }
+        filterChain.doFilter(request, response);
     }
 }

--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
@@ -2,6 +2,7 @@ package io.codebuddy.gatewayservice.filter;
 
 import io.codebuddy.gatewayservice.security.TokenVerifier;
 import io.codebuddy.gatewayservice.security.VerifiedUser;
+import io.codebuddy.gatewayservice.web.MutableHttpServletRequest;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,9 +14,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-//헤더에 X-User_id, X-User-Role 주입
+//헤더에 X-User-Id, X-User-Role 주입
 @Component
 public class AuthHeaderInjectFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
 
     private final TokenVerifier tokenVerifier;
 
@@ -28,11 +32,19 @@ public class AuthHeaderInjectFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
         String authHeader = request.getHeader("Authorization");
+        HttpServletRequest requestToUse = request;
 
         if (authHeader != null) {
             VerifiedUser verified;
             try {
                 verified = tokenVerifier.verify(authHeader);
+
+                // 헤더 주입: MutableHttpServletRequest를 사용하여 X-User-Id, X-User-Role 헤더 추가
+                MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
+                mutableRequest.putHeader(USER_ID_HEADER, verified.userId());
+                mutableRequest.putHeader(USER_ROLE_HEADER, verified.role());
+                requestToUse = mutableRequest;
+
             } catch (HttpClientErrorException e) {
                 // User-Service에서 받은 상태 코드를 그대로 설정
                 response.setStatus(e.getStatusCode().value());
@@ -51,8 +63,8 @@ public class AuthHeaderInjectFilter extends OncePerRequestFilter {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             }
-
         }
-        filterChain.doFilter(request, response);
+
+        filterChain.doFilter(requestToUse, response);
     }
 }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/auth/token/security/filter/JwtExceptionFilter.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/auth/token/security/filter/JwtExceptionFilter.java
@@ -16,6 +16,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import io.jsonwebtoken.security.SignatureException;
+
+import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -65,6 +67,9 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         body.put("code", code);
         body.put("message", message);
 
-        objectMapper.writeValue(response.getWriter(), body);
+        String bodyString = objectMapper.writeValueAsString(body);
+        PrintWriter writer = response.getWriter();
+
+        writer.write(bodyString);
     }
 }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/exception/GlobalExceptionHandler.java
@@ -14,29 +14,30 @@ import java.util.stream.Collectors;
 /*
 정확한 에러 메시지를 사용자에게 출력하기 위한 메서드
  */
-@RestControllerAdvice(assignableTypes = {LoginController.class, MemberController.class})
+@RestControllerAdvice(assignableTypes = { LoginController.class, MemberController.class })
 public class GlobalExceptionHandler {
-    /**
-     * @Valid 검증 실패 시 호출됨
-     */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        /**
+         * @Valid 검증 실패 시 호출됨
+         */
+        @ExceptionHandler(MethodArgumentNotValidException.class)
+        protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+                        MethodArgumentNotValidException e) {
 
-        // 에러 상세 정보 추출
-        List<ErrorResponse.FieldErrorDetail> fieldErrors = e.getBindingResult().getFieldErrors().stream()
-                .map(error -> ErrorResponse.FieldErrorDetail.builder()
-                        .field(error.getField())
-                        .value(String.valueOf(error.getRejectedValue()))
-                        .reason(error.getDefaultMessage()) // DTO에 적은 message가 여기 들어감
-                        .build())
-                .collect(Collectors.toList());
+                // 에러 상세 정보 추출
+                List<ErrorResponse.FieldErrorDetail> fieldErrors = e.getBindingResult().getFieldErrors().stream()
+                                .map(error -> ErrorResponse.FieldErrorDetail.builder()
+                                                .field(error.getField())
+                                                .value(String.valueOf(error.getRejectedValue()))
+                                                .reason(error.getDefaultMessage()) // DTO에 적은 message가 여기 들어감
+                                                .build())
+                                .collect(Collectors.toList());
 
-        ErrorResponse response = ErrorResponse.builder()
-                .code("INVALID_INPUT_VALUE")
-                .message("입력값이 유효하지 않습니다.")
-                .errors(fieldErrors)
-                .build();
+                ErrorResponse response = ErrorResponse.builder()
+                                .code("INVALID_INPUT_VALUE")
+                                .message("입력값이 유효하지 않습니다.")
+                                .errors(fieldErrors)
+                                .build();
 
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-    }
+                return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #172

---

## 🧩 구현한 기능
- [x] 각 서비스에서 구현되어 작동하던 예외처리 핸들러에 의한 응답이 gateway에서 덮어쓰던 문제 해결
- [x] gateway에서 헤더 주입이 비정상적으로 주입되던 문제 수정

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 중복된 정보로 회원가입 요청/훼손된 토큰으로 각 서비스 요청 시도
2. 각 서비스단에서 적절한 예외 발생 및 핸들러를 통한 응답 반환
3. 결과를 gateway에서 그대로 반환

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 gateway에서 모든 요청과 응답을 인터셉트 하는 로직까지는 같으나, 이미 발생한 예외와 처리된 응답이 있다면 그대로 반환하도록 수정
- X-헤더 주입 방식 변경
---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman  테스트

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한지 확인 부탁드립니다.
- 예외 처리 방식에 대한 의견을 주시면 좋겠습니다.
- 성능 또는 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] 성능 개선
- [ ] 예외 처리 보완
- [ ] 테스트 코드 보강
- [ ] 회원가입 중복 요청 시 예외 발행 및 핸들러 구현 필요
