### PR TITLE
[#177] catalog 서비스 내 예외처리 핸들러 고도화

### DIFF
--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/exception/ProductExceptionHandler.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/exception/ProductExceptionHandler.java
@@ -41,12 +41,5 @@ public class ProductExceptionHandler {
     }
 
 
-    //그 외 서버에러
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
-        String errorMessage = "상품 서비스에 문제가 발생했습니다. 관리자에게 문의하세요.";
-        log.error("Product Service Unhandled Error: ",e); // 진짜 서버 에러는 Error 로그
-        return ResponseEntity.internalServerError()
-                .body(new ErrorResponse(null, errorMessage, Instant.now()));
-    }
+
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/exception/SellerErrorCode.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/exception/SellerErrorCode.java
@@ -8,6 +8,9 @@ public enum SellerErrorCode {
     // 이미 등록된 판매자 (409 Conflict)
     ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 등록된 판매자입니다."),
 
+    // 이미 사용중인 판매자 이름 (409 Conflict)
+    SELLER_NAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 판매자 이름입니다."),
+
     // 판매자를 찾을 수 없음 (404 Not Found)
     SELLER_NOT_FOUND(HttpStatus.NOT_FOUND, "판매자 정보를 찾을 수 없습니다."),
 

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/repository/SellerJpaRepository.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/repository/SellerJpaRepository.java
@@ -12,5 +12,8 @@ public interface SellerJpaRepository extends JpaRepository<Seller, Long> {
     //이미 판매자로 등록된 멤버인지 검사
     boolean existsByMemberId(Long memberId);
 
+    // 판매자 이름 중복 체크
+    boolean existsBySellerName(String sellerName);
+
     Optional<Seller> findByMemberId(Long memberId);
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/repository/SellerJpaRepository.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/repository/SellerJpaRepository.java
@@ -15,5 +15,8 @@ public interface SellerJpaRepository extends JpaRepository<Seller, Long> {
     // 판매자 이름 중복 체크
     boolean existsBySellerName(String sellerName);
 
+    // 판매자 이름 중복 체크 (수정 시 - 자기 자신 제외)
+    boolean existsBySellerNameAndSellerIdNot(String sellerName, Long sellerId);
+
     Optional<Seller> findByMemberId(Long memberId);
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/service/SellerService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/service/SellerService.java
@@ -33,6 +33,12 @@ public class SellerService {
                 .ifPresent(seller -> {
                     throw new SellerException(SellerErrorCode.ALREADY_REGISTERED);
                 });
+
+        // 판매자 이름 중복 체크
+        if (sellerJpaRepository.existsBySellerName(request.sellerName())) {
+            throw new SellerException(SellerErrorCode.SELLER_NAME_DUPLICATED);
+        }
+
         // seller Entity 생성
         Seller seller = Seller.builder()
                 .memberId(loginMemberId)

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/service/SellerService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/sellers/service/SellerService.java
@@ -79,6 +79,11 @@ public class SellerService {
         Seller seller = sellerJpaRepository.findByMemberId(loginMemberId)
                 .orElseThrow(() -> new SellerException(SellerErrorCode.UNAUTHORIZED_ACCESS));
 
+        // 자기 자신을 제외한 판매자 이름 중복 체크
+        if (sellerJpaRepository.existsBySellerNameAndSellerIdNot(request.sellerName(), seller.getSellerId())) {
+            throw new SellerException(SellerErrorCode.SELLER_NAME_DUPLICATED);
+        }
+
         seller.update(request.sellerName());
     }
 

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/stores/exception/StoreExceptionHandler.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/stores/exception/StoreExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.codebuddy.closetbuddy.domain.catalog.stores.exception;
 
-import io.codebuddy.closetbuddy.domain.catalog.sellers.exception.SellerException;
+import io.codebuddy.closetbuddy.domain.catalog.products.controller.ProductApiController;
+import io.codebuddy.closetbuddy.domain.catalog.products.service.ProductService;
 import io.codebuddy.closetbuddy.domain.catalog.stores.controller.StoreApiController;
 import io.codebuddy.closetbuddy.domain.catalog.stores.service.StoreService;
 import io.codebuddy.closetbuddy.domain.catalog.web.ErrorResponse;
@@ -15,12 +16,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.time.Instant;
 
 //Store 도메인의 예외만 잡도록 격리
-@RestControllerAdvice(assignableTypes = {StoreApiController.class, StoreService.class})
+@RestControllerAdvice(assignableTypes = {StoreApiController.class, StoreService.class, ProductService.class, ProductApiController.class})
 public class StoreExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(StoreExceptionHandler.class);
 
-    @ExceptionHandler(SellerException.class)
+    @ExceptionHandler(StoreException.class)
     public ResponseEntity<ErrorResponse> handleStoreException(StoreException e) {
         StoreErrorCode errorCode = e.getErrorCode();
         //예외를 잡아 서버 로그로 출력


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #177

---

## 🧩 구현한 기능
- [x] 존재하지 않는 상점에 대한 상품 등록 시 상점이 존재하지 않음 에러코드 및 응답 반환
- [x] 판매자 등록 시 이미 존재하는 판매자 이름으로 등록하지 못하도록 예외 처리
- [x] 판매자 이름 변경 시 이미 존재하는 판매자 이름으로 변경하지 못하도록 예외 처리

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 존재하지 않는 상점에 대한 상품 등록/이미 존재하는 판매자 이름으로 판매자 등록. 변경 시도
2. 상점 서비스에서 예외를 잡아 404에러 반환/jpa 리포지토리를 활용해 존재하는 판매자 이름 검사 후 등록, 변경 진행
3. 결과를 404 NotFound 반환/409 Conflict 반환

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 ProductExceptionHandler에서  Exception 클래스 예외를 처리하는 메서드를 제거
- 등록된 판매자 이름을 검사하는 메서드, 로직 추가

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman 테스트

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한지 확인 부탁드립니다.
- 예외 처리 방식에 대한 의견을 주시면 좋겠습니다.
- 성능 또는 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] 서비스 분리 후 catalog 서비스 전역 핸들러 구현
- [ ] 예외 처리 보완
