### PR TITLE
[#181] Interceptor 제거 및 feign호출 간 gateway 검증 신뢰 기반 통신 구현

### DIFF
--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
@@ -18,8 +18,8 @@ import java.io.IOException;
 @Component
 public class AuthHeaderInjectFilter extends OncePerRequestFilter {
 
-    private static final String USER_ID_HEADER = "X-User-Id";
-    private static final String USER_ROLE_HEADER = "X-User-Role";
+    private static final String USER_ID_HEADER = "X-USER-ID";
+    private static final String USER_ROLE_HEADER = "X-USER-ROLE";
 
     private final TokenVerifier tokenVerifier;
 
@@ -39,7 +39,7 @@ public class AuthHeaderInjectFilter extends OncePerRequestFilter {
             try {
                 verified = tokenVerifier.verify(authHeader);
 
-                // 헤더 주입: MutableHttpServletRequest를 사용하여 X-User-Id, X-User-Role 헤더 추가
+                // 헤더 주입: MutableHttpServletRequest를 사용하여 X-USER-ID, X-USER-ROLE 헤더 추가
                 MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
                 mutableRequest.putHeader(USER_ID_HEADER, verified.userId());
                 mutableRequest.putHeader(USER_ROLE_HEADER, verified.role());

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/carts/ProductClient.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/carts/ProductClient.java
@@ -5,7 +5,6 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import java.util.List;
 
 @FeignClient(name = "main-service")
 public interface ProductClient {

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/FeignConfig.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/common/feign/FeignConfig.java
@@ -1,15 +1,9 @@
 package io.codebuddy.closetbuddy.domain.common.feign;
 
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.codec.ErrorDecoder;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
  * Feign Client 설정
@@ -23,30 +17,4 @@ public class FeignConfig {
         return new FeignErrorDecoder();
     }
 
-    /**
-     * 호출한 HTTP 요청의 Authorization 헤더를 feign 호출 시 그대로 전달
-     * 결과 : Gateway에서 주입한 인증 정보(X-USER-ID, X-USER-ROLE)가 그대로 user-service에서 전달
-     */
-    @Bean
-    public RequestInterceptor authHeaderInterceptor() {
-        return (RequestTemplate template) -> {
-            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-
-            if ( attributes != null) {
-                HttpServletRequest request = attributes.getRequest();
-                String authorization = request.getHeader("Authorization");
-
-                log.debug("Feign RequestInterceptor - Authorization 헤더 : {}",
-                        authorization != null ? "존재 (길이: " + authorization.length() + ")" : "없음");
-
-                if (authorization != null) {
-                    template.header("Authorization", authorization);
-                } else {
-                    log.warn("Feign 호출 시 Authorization Header가 없습니다. 요청 URI : {}", request.getRequestURI());
-                }
-            }else {
-                log.warn("Feign RequestInterceptor - RequestAttributes가 null입니다. RequestContextHolder에서 요청 정보를 가져올 수 없습니다.");
-            }
-        };
-    }
 }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/WebConfig.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package io.codebuddy.userservice.domain.common.config;
+
+import io.codebuddy.userservice.domain.common.web.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/exception/AuthHeaderMissingException.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/exception/AuthHeaderMissingException.java
@@ -1,0 +1,7 @@
+package io.codebuddy.userservice.domain.common.exception;
+
+public class AuthHeaderMissingException extends RuntimeException {
+    public AuthHeaderMissingException(String message) {
+        super(message);
+    }
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/web/CurrentUser.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/web/CurrentUser.java
@@ -1,0 +1,11 @@
+package io.codebuddy.userservice.domain.common.web;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/web/CurrentUserArgumentResolver.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/web/CurrentUserArgumentResolver.java
@@ -1,0 +1,38 @@
+package io.codebuddy.userservice.domain.common.web;
+
+import io.codebuddy.userservice.domain.common.exception.AuthHeaderMissingException;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String USER_ID_HEADER =  "X-USER-ID";
+    private static final String ROLE_HEADER = "X-USER-ROLE";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(CurrentUserInfo.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory){
+        String userId = webRequest.getHeader(USER_ID_HEADER);
+        String role = webRequest.getHeader(ROLE_HEADER);
+
+        if (!StringUtils.hasText(userId) || !StringUtils.hasText(role)){
+            throw new AuthHeaderMissingException("X-USER-ID or X-USER-ROLE header missing");
+        }
+
+        return new CurrentUserInfo(userId, role);
+    }
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/web/CurrentUserInfo.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/web/CurrentUserInfo.java
@@ -1,0 +1,4 @@
+package io.codebuddy.userservice.domain.common.web;
+
+public record CurrentUserInfo(String userId, String role) {
+}

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberController.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberController.java
@@ -5,15 +5,11 @@ import io.codebuddy.userservice.domain.auth.token.security.principal.MemberDetai
 import io.codebuddy.userservice.domain.member.dto.MemberResponse;
 import io.codebuddy.userservice.domain.member.dto.MemberUpdateRequest;
 import io.codebuddy.userservice.domain.member.service.MemberService;
-import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import io.codebuddy.userservice.domain.common.web.CurrentUser;
-import io.codebuddy.userservice.domain.common.web.CurrentUserInfo;
 
 @RestController
 @RequestMapping("/api/v1/members")

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberController.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberController.java
@@ -42,24 +42,4 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    // 판매자 권한 부여
-    @PostMapping("/me/seller")
-    @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<Long> registerSeller(
-            @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser) {
-
-        memberCommandService.registerSeller(Long.parseLong(currentUser.userId()));
-
-        return ResponseEntity.ok().build();
-    }
-
-    // 판매자 등록 해제 (역할 해제)
-    @DeleteMapping("/me/seller")
-    public ResponseEntity<Void> unregisterSeller(
-            @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser) {
-
-        memberCommandService.revokeSeller(Long.parseLong(currentUser.userId()));
-
-        return ResponseEntity.ok().build();
-    }
 }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberController.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/member/controller/MemberController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import io.codebuddy.userservice.domain.common.web.CurrentUser;
+import io.codebuddy.userservice.domain.common.web.CurrentUserInfo;
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -44,9 +46,9 @@ public class MemberController {
     @PostMapping("/me/seller")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Long> registerSeller(
-            @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails principal) {
+            @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser) {
 
-        memberCommandService.registerSeller(principal.getId());
+        memberCommandService.registerSeller(Long.parseLong(currentUser.userId()));
 
         return ResponseEntity.ok().build();
     }
@@ -54,9 +56,9 @@ public class MemberController {
     // 판매자 등록 해제 (역할 해제)
     @DeleteMapping("/me/seller")
     public ResponseEntity<Void> unregisterSeller(
-            @Parameter(hidden = true) @AuthenticationPrincipal MemberDetails principal) {
+            @Parameter(hidden = true) @CurrentUser CurrentUserInfo currentUser) {
 
-        memberCommandService.revokeSeller(principal.getId());
+        memberCommandService.revokeSeller(Long.parseLong(currentUser.userId()));
 
         return ResponseEntity.ok().build();
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #181

---

## 🧩 구현한 기능
- [x] feignConfig 클래스 내 인터셉터 로직 제거
- [x] user-service 내 내부 api는 그대로 jwt인증을 진행
- [x] main-service를 통해 feign호출 시 gateway의 헤더 검증을 신뢰하고 내부 api 호출을 통해 동기 통신 구현

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 gateway를 거쳐 main-service의 판매자 등록/해제 api 호출
2. main-service에서는 gateway의 검증을 신뢰하고 주입된 헤더를 통해 사용자 인식 및 역할 인지
3. main-service에서 feign호출을 통해 user-service의 판매자 역할 변경 요청
4. user-service는 선행된 gateway의 헤더 검증을 신뢰하고 즉시 내부 api호출을 통해 판매자 역할변경

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 feignConfig의 인터셉터를 통해 검증을 이중으로 진행했던 방식에서 gateway에서 선행된 검증을 신뢰하고 내부 api호출 진행

### 🗂 구조 변경
- main-service에서 사용하는 커스텀 어노테이션 클래스 및 패키지 구현
- feignConfig 클래스 내 인터셉터 메서드 제거

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman 테스트

---

## 🔍 리뷰 요청 포인트
- 성능 또는 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] 후속 기능 중 user-service 내 커스터 어노테이션 불필요시 삭제필요
- [ ] 예외 처리 보완
