### PR TITLE
Trust Zone 인증시스템 개선

### DIFF
--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/filter/AuthHeaderInjectFilter.java
@@ -43,6 +43,13 @@ public class AuthHeaderInjectFilter extends OncePerRequestFilter {
                 MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
                 mutableRequest.putHeader(USER_ID_HEADER, verified.userId());
                 mutableRequest.putHeader(USER_ROLE_HEADER, verified.role());
+
+                // 추가할 코드: user-service가 아닌 서비스로 라우팅되는 경우 Authorization 헤더 제거
+                String requestPath = request.getRequestURI();
+                if (!isUserServicePath(requestPath)) {
+                    mutableRequest.removeHeader("Authorization");
+                }
+
                 requestToUse = mutableRequest;
 
             } catch (HttpClientErrorException e) {
@@ -67,4 +74,21 @@ public class AuthHeaderInjectFilter extends OncePerRequestFilter {
 
         filterChain.doFilter(requestToUse, response);
     }
+
+    /**
+     * user-service로 라우팅되는 경로인지 확인
+     * user-service는 JwtAuthenticationFilter를 통해 JWT 토큰 기반 인증을 사용하므로
+     * Authorization 헤더를 유지해야 하므로 user-service로 라우팅 할 시 헤더 유지
+     *
+     * user-service의 MemberController는 @AuthenticationPrincipal을 사용하여
+     * SecurityContextHolder에서 인증 정보를 가져오므로 JWT가 필수
+     *
+     * 요청 경로를 파악하고 필요에따라 헤더 유지
+     */
+    private boolean isUserServicePath(String path) {
+        return path.startsWith("/api/v1/auth/")
+                || path.startsWith("/api/v1/authc")
+                || path.startsWith("/api/v1/members/");
+    }
+
 }

--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/web/MutableHttpServletRequest.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/web/MutableHttpServletRequest.java
@@ -8,17 +8,31 @@ import java.util.*;
 public class MutableHttpServletRequest extends HttpServletRequestWrapper {
 
     private final Map<String, String> customHeaders = new HashMap<>();
+    // 무시할 헤더의 리스트를 중복방지를 적용하여 관리하기 위해 set 활용
+    // 객체는 불변객체로, 삭제가 불가능하기 때문에 Authorization의 전파를 막기 위해서 전파하지 않을 헤더
+    // 목록을 사용
+    private final Set<String> removedHeaders = new HashSet<>();
 
     public MutableHttpServletRequest(HttpServletRequest request) {
         super(request);
     }
 
+    // 커스텀 헤더 주입 메서드
     public void putHeader(String name, String value) {
         this.customHeaders.put(name, value);
     }
 
+    // Authorization헤더를 제거하기위한 헤더 제거 메서드
+    public void removeHeader(String name) {
+        this.customHeaders.remove(name);
+    }
+
     @Override
     public String getHeader(String name) {
+        // 제거된 헤더는 null 반환 -> 네트워크 전파시 Authorization 헤더가 복사되지 않음
+        if (removedHeaders.contains(name.toLowerCase())) {
+            return null;
+        }
         String headerValue = customHeaders.get(name);
         if(headerValue != null) {
             return headerValue;
@@ -31,13 +45,21 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
         Set<String> names = new HashSet<>(customHeaders.keySet());
         Enumeration<String> base = super.getHeaderNames();
         while (base.hasMoreElements()) {
-            names.add(base.nextElement());
+            String headerName = base.nextElement();
+            // 제거된 헤더는 목록에서 제외 즉, gateway내에서만 Authorization 헤더가 남아있고 이외 서비스 전파시 제거됨
+            if (!removedHeaders.contains(headerName.toLowerCase())) {
+                names.add(headerName);
+            }
         }
         return Collections.enumeration(names);
     }
 
     @Override
     public Enumeration<String> getHeaders(String name) {
+        // 제거된 헤더는 빈 목록 반환
+        if (removedHeaders.contains(name.toLowerCase())) {
+            return Collections.emptyEnumeration();
+        }
         if (customHeaders.containsKey(name)) {
             return Collections.enumeration(List.of(customHeaders.get(name)));
         }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #189

---

## 🧩 구현한 기능
- [x] user-service를 제외한 마이크로 서비스 요청시 authorization 헤더 전파를 막기 위한 헤더 무시 로직 구현
- [x] user-service가 아닌 서비스로 라우팅시에만 헤더 제거 로직을 수행할 수 있도록 변경

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 user-service를 제외한 서비스에 요청
2. 서버에서 Authorization 헤더를 제외하고 요청
3. 각 마이크로 서비스에서는 Authorization헤더 없이 gateway의 검증을 신뢰하고 서비스로직 수행

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 요청시 헤더의 Authorization 헤더가 전파되는 로직에서 해당 헤더를 제외하고 요청하는 로직으로 수정

### 🗂 구조 변경
- 패키지 구조 변경 여부 없음

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman 테스트

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한지 확인 부탁드립니다.
- 각 마이크로 서비스에서 요청시 헤더가 발견되면 피드백 바랍니다.

---

## 🚀 예상 추가 작업
- [ ] 예외 처리 보완
- [ ] 각 마이크로 서비스 테스트시 헤더 확인
