### PR TITLE
[#192] 상품 검색에 대해 ELS 구현

### DIFF
--- a/main-service/build.gradle
+++ b/main-service/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     //h2
     testImplementation 'com.h2database:h2'
 
+    //elastic-search
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 }
 dependencyManagement {
     imports {

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
@@ -12,6 +12,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -235,7 +238,7 @@ public class ProductController {
         return ResponseEntity.ok(response);
     }
 
-    //자동 완성
+    //자동 완성(띄어쓰기 고려)
     @GetMapping("/suggestions")
     public ResponseEntity<List<String>> fetchSuggestions(
             @RequestParam("prefix") String prefix,
@@ -244,6 +247,21 @@ public class ProductController {
         List<String> suggestions = productService.getSuggestions(prefix, limit);
 
         return ResponseEntity.ok(suggestions);
+    }
+
+    /*
+    상품 검색
+    기본 검색 : http://localhost:8080/product/search?keyword=나이키
+    페이징 : http://localhost:8080/product/search?keyword=나이키&page=0&size=10
+     */
+    @GetMapping("/products/search")
+    public ResponseEntity<Page<ProductResponse>> searchProducts(
+            @RequestParam(name = "keyword") String keyword,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<ProductResponse> result = productService.searchProducts(keyword, pageable);
+
+        return ResponseEntity.ok(result);
     }
 
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
@@ -234,4 +234,16 @@ public class ProductController {
         List<ProductResponse> response = productService.getAllProducts();
         return ResponseEntity.ok(response);
     }
+
+    //자동 완성
+    @GetMapping("/suggestions")
+    public ResponseEntity<List<String>> fetchSuggestions(
+            @RequestParam("prefix") String prefix,
+            @RequestParam(value = "limit", defaultValue = "10") Integer limit
+    ) {
+        List<String> suggestions = productService.getSuggestions(prefix, limit);
+
+        return ResponseEntity.ok(suggestions);
+    }
+
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
@@ -239,6 +239,16 @@ public class ProductController {
     }
 
     //자동 완성(띄어쓰기 고려)
+    @Operation(
+            summary = "자동 완성",
+            description = "검색어 입력 시 자동완성 결과를 보여줍니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "자동 완성"
+            )
+    })
     @GetMapping("/suggestions")
     public ResponseEntity<List<String>> fetchSuggestions(
             @RequestParam("prefix") String prefix,
@@ -254,6 +264,16 @@ public class ProductController {
     기본 검색 : http://localhost:8080/product/search?keyword=나이키
     페이징 : http://localhost:8080/product/search?keyword=나이키&page=0&size=10
      */
+    @Operation(
+            summary = "상품 검색",
+            description = "키워드를 입력하여 관련 상품을 검색합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "검색 성공"
+            )
+    })
     @GetMapping("/products/search")
     public ResponseEntity<Page<ProductResponse>> searchProducts(
             @RequestParam(name = "keyword") String keyword,

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductMapper.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductMapper.java
@@ -1,0 +1,20 @@
+package io.codebuddy.closetbuddy.domain.catalog.products.model.dto;
+
+import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.Product;
+import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.ProductDocument;
+
+public class ProductMapper {
+    public static ProductDocument toProductDocument(Product product){
+        return new ProductDocument(
+
+                String.valueOf(product.getProductId()),
+                product.getProductName(),
+                product.getProductPrice(),
+                product.getProductStock(),
+                String.valueOf(product.getCategory()),
+                product.getStore().getStoreName(),
+                product.getImageUrl()
+        );
+
+    }
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductResponse.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductResponse.java
@@ -1,6 +1,7 @@
 package io.codebuddy.closetbuddy.domain.catalog.products.model.dto;
 
 import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.Product;
+import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.ProductDocument;
 
 public record ProductResponse(
         Long productId,
@@ -20,6 +21,18 @@ public record ProductResponse(
                 product.getProductStock(),
                 product.getCategory(),
                 product.getStore().getStoreName()
+        );
+    }
+
+    // document -> productResponse
+    public static ProductResponse fromDocument(ProductDocument doc) {
+        return new ProductResponse(
+                Long.parseLong(doc.getId()),
+                doc.getProductName(),
+                doc.getProductPrice(),
+                doc.getProductStock(),
+                Category.valueOf(doc.getCategory()),
+                doc.getStoreName()
         );
     }
 }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
@@ -1,0 +1,58 @@
+package io.codebuddy.closetbuddy.domain.catalog.products.model.entity;
+
+
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.elasticsearch.annotations.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@ToString
+// 인덱스 이름 지정
+@Document(indexName = "products")
+// 커스텀 설정 파일
+@Setting(settingPath = "/elasticsearch/products-settings.json")
+public class ProductDocument {
+
+    @Id
+    private String id;
+
+    @MultiField(
+            // 일반적인 키워드 검색
+            mainField = @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_synonym_analyzer"),
+            otherFields = {
+                    // 부분일치
+                    @InnerField(suffix = "ngram", type = FieldType.Text, analyzer = "edge_ngram_analyzer", searchAnalyzer = "nori_synonym_analyzer"),
+                    // 상품명 정렬, 정확히 그 이름인 상품 검색
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword, normalizer = "lowercase_normalizer")
+            }
+    )
+    private String productName;
+
+    @Field(type = FieldType.Long)
+    private Long productPrice;
+
+    @Field(type = FieldType.Integer)
+    private int productStock;
+
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "nori_analyzer"),
+            otherFields = {
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword)
+            }
+    )
+    private String storeName;
+
+    // 동의어 설정
+    @Field(type = FieldType.Text, analyzer = "nori_synonym_analyzer")
+    private String category;
+
+    // 이미지를 검색할 필요 없으므로 색인 제외 (저장 공간 절약)
+    @Field(type = FieldType.Keyword, index = false)
+    private String imageUrl;
+
+
+
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/repository/ProductElasticRepository.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/repository/ProductElasticRepository.java
@@ -1,0 +1,48 @@
+package io.codebuddy.closetbuddy.domain.catalog.products.repository;
+
+import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.ProductDocument;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchPage;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ProductElasticRepository extends ElasticsearchRepository<ProductDocument,String> {
+
+    // query : ?0 : 첫번째 파라미터
+    // fields : 쿼리 결과에 가중치
+    // best_fields : 필드(name,ngram) 중 가장 점수가 높은 필드의 점수를 document의 최종 점수로 삼음
+    // fuzziness:  오타 허용 범위
+    @Query("""
+    {
+        "multi_match": {
+            "query": "?0",
+            "fields": [
+                "productName^3",
+                "productName.ngram^3",
+                "storeName^2",
+                "category"
+            ],
+            "type": "best_fields",
+            "fuzziness": "AUTO"
+        }
+    }
+    """)
+    SearchPage<ProductDocument> searchByKeyword(String keyword, Pageable pageable);
+
+    // bool_prefix : 띄어쓰기가 포함된 자동완성
+    @Query("""
+    {
+        "multi_match": {
+            "query": "#{#prefix}",
+            "type": "bool_prefix",
+            "fields": [
+                "productName",
+                "productName.ngram"
+            ]
+        }
+    }
+    """)
+    SearchPage<ProductDocument> autoComplete(String prefix, Pageable pageable);
+
+}

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
@@ -2,10 +2,12 @@ package io.codebuddy.closetbuddy.domain.catalog.products.service;
 
 import io.codebuddy.closetbuddy.domain.catalog.products.exception.ProductErrorCode;
 import io.codebuddy.closetbuddy.domain.catalog.products.exception.ProductException;
+import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductMapper;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductResponse;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.UpdateProductRequest;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductCreateRequest;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.Product;
+import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.ProductDocument;
 import io.codebuddy.closetbuddy.domain.catalog.products.repository.ProductElasticRepository;
 import io.codebuddy.closetbuddy.domain.catalog.products.repository.ProductJpaRepository;
 
@@ -42,6 +44,10 @@ public class ProductService {
         Product product = request.toEntity(store);
         productJpaRepository.save(product);
 
+        //ELS 상품 등록
+        ProductDocument productDocument= ProductMapper.toProductDocument(product);
+        productElasticRepository.save(productDocument);
+
 
     }
 
@@ -61,6 +67,13 @@ public class ProductService {
                 request.imageUrl(),
                 product.getCategory()
         );
+
+        //ELS 수정
+        ProductDocument productDocument=ProductMapper.toProductDocument(product);
+
+        //ELS의 save : 없으면 create, 있으면 update
+        productElasticRepository.save(productDocument);
+
     }
 
     //상품 상세조회(단건)
@@ -100,6 +113,10 @@ public class ProductService {
         //상품을 삭제할 권한이 있는 회원인지 검증
         validateProductOwner(memberId, product);
         productJpaRepository.delete(product);
+
+        //ELS 데이터 삭제
+        ProductDocument productDocument=ProductMapper.toProductDocument(product);
+        productElasticRepository.delete(productDocument);
     }
 
     // (상점 주인 확인용) 검증 로직

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
@@ -18,10 +18,18 @@ import io.codebuddy.closetbuddy.domain.catalog.stores.exception.StoreException;
 import io.codebuddy.closetbuddy.domain.catalog.stores.model.entity.Store;
 import io.codebuddy.closetbuddy.domain.catalog.stores.repository.StoreJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchPage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -117,6 +125,35 @@ public class ProductService {
         //ELS 데이터 삭제
         ProductDocument productDocument=ProductMapper.toProductDocument(product);
         productElasticRepository.delete(productDocument);
+    }
+
+    //검색 자동 완성
+    public List<String> getSuggestions(String prefix, Integer limit) {
+
+        // Pageable로 개수 제한
+        Pageable pageable = PageRequest.of(0, limit);
+        // SearchPage : SearchHits + Page
+        SearchPage<ProductDocument> searchPage = productElasticRepository.autoComplete(prefix, pageable);
+        // 검색된 결과에서 searchHits만 분리
+        SearchHits<ProductDocument> searchHits = searchPage.getSearchHits();
+
+        // 결과 담을 리스트와 중복 확인용 Set 생성
+        // '나이키' 검색 시 '나이키 신발'이 100개 출력되지 않도록 중복 제거
+        List<String> resultList = new ArrayList<>();
+        Set<String> uniqueChecker = new HashSet<>();
+
+        for (SearchHit<ProductDocument> hit : searchHits) {
+            ProductDocument product = hit.getContent();
+            String name = product.getProductName();
+
+            // 중복 제거 로직 (Set에 없으면 추가)
+            if (!uniqueChecker.contains(name)) {
+                uniqueChecker.add(name); // Set에 등록
+                resultList.add(name);    // 결과 리스트에 추가
+            }
+        }
+
+        return resultList;
     }
 
     // (상점 주인 확인용) 검증 로직

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
@@ -2,10 +2,7 @@ package io.codebuddy.closetbuddy.domain.catalog.products.service;
 
 import io.codebuddy.closetbuddy.domain.catalog.products.exception.ProductErrorCode;
 import io.codebuddy.closetbuddy.domain.catalog.products.exception.ProductException;
-import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductMapper;
-import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductResponse;
-import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.UpdateProductRequest;
-import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductCreateRequest;
+import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.*;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.Product;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.ProductDocument;
 import io.codebuddy.closetbuddy.domain.catalog.products.repository.ProductElasticRepository;
@@ -18,6 +15,8 @@ import io.codebuddy.closetbuddy.domain.catalog.stores.exception.StoreException;
 import io.codebuddy.closetbuddy.domain.catalog.stores.model.entity.Store;
 import io.codebuddy.closetbuddy.domain.catalog.stores.repository.StoreJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -154,6 +153,27 @@ public class ProductService {
         }
 
         return resultList;
+    }
+
+    // 상품 검색
+    public Page<ProductResponse> searchProducts(String keyword, Pageable pageable) {
+
+        // ELS에서 검색 결과 가져오기
+        SearchPage<ProductDocument> searchPage = productElasticRepository.searchByKeyword(keyword, pageable);
+
+        // 결과를 담을 리스트 생성
+        List<ProductResponse> responseList = new ArrayList<>();
+
+        for (SearchHit<ProductDocument> hit : searchPage.getSearchHits()) {
+            ProductDocument document = hit.getContent();
+
+            ProductResponse dto = ProductResponse.fromDocument(document);
+
+            responseList.add(dto);
+        }
+
+        // PageImpl로 반환 (데이터 리스트, 페이징 정보, 전체 개수)
+        return new PageImpl<>(responseList, pageable, searchPage.getTotalElements());
     }
 
     // (상점 주인 확인용) 검증 로직

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
@@ -6,6 +6,7 @@ import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductRespons
 import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.UpdateProductRequest;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.dto.ProductCreateRequest;
 import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.Product;
+import io.codebuddy.closetbuddy.domain.catalog.products.repository.ProductElasticRepository;
 import io.codebuddy.closetbuddy.domain.catalog.products.repository.ProductJpaRepository;
 
 import io.codebuddy.closetbuddy.domain.catalog.sellers.repository.SellerJpaRepository;
@@ -26,10 +27,11 @@ public class ProductService {
 
     private final ProductJpaRepository productJpaRepository;
     private final StoreJpaRepository storeJpaRepository;
+    private final ProductElasticRepository productElasticRepository;
 
     //상품 등록
     @Transactional
-    public Long createProduct(Long memberId, Long storeId, ProductCreateRequest request) {
+    public void createProduct(Long memberId, Long storeId, ProductCreateRequest request) {
         Store store = storeJpaRepository.findById(storeId)
                 .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
 
@@ -38,7 +40,9 @@ public class ProductService {
 
         //상품 생성
         Product product = request.toEntity(store);
-        return productJpaRepository.save(product).getProductId();
+        productJpaRepository.save(product);
+
+
     }
 
     //상품 수정

--- a/main-service/src/main/resources/elasticsearch/products-settings.json
+++ b/main-service/src/main/resources/elasticsearch/products-settings.json
@@ -33,9 +33,54 @@
       "synonym_filter": {
         "type": "synonym_graph",
         "synonyms": [
-          "삼성,샘숭,삼송,samsung",
-          "lg,엘지,앨지,엘쥐,앨쥐",
-          "바지, 팬츠, pants, 슬랙스, 조거팬츠, 레깅스, 하의"
+          "블랙, black, 검정, 검은색, 흑색",
+          "화이트, white, 흰색, 하얀색, 백색",
+          "그레이, gray, grey, 회색, 쥐색",
+          "차콜, charcoal, 먹색",
+          "네이비, navy, 곤색, 남색",
+          "베이지, beige, 연갈색",
+          "아이보리, ivory, 크림, 크림색",
+          "카키, khaki, 국방색",
+          "브라운, brown, 갈색, 밤색",
+          "블루, blue, 파랑, 파란색",
+          "그린, green, 초록, 초록색, 녹색",
+          "레드, red, 빨강, 빨간색",
+          "옐로우, yellow, 노랑, 노란색",
+          "핑크, pink, 분홍, 분홍색",
+          "퍼플, purple, 보라, 보라색, 바이올렛",
+
+          "코튼, cotton, 면, 순면",
+          "린넨, linen, 마, 리넨",
+          "울, wool, 모, 양모",
+          "폴리, poly, 폴리에스테르, polyester",
+          "데님, denim, 청, 진, jean",
+          "스판, span, spandex, 스판덱스, 신축성",
+          "트위드, tweed",
+
+          "스트라이프, stripe, 줄무늬, 단가라",
+          "체크, check, 격자, 타탄",
+          "도트, dot, 땡땡이, 물방울",
+          "솔리드, solid, 무지, 민무늬",
+
+          "오버핏, overfit, 루즈핏, 박시, 박스핏, oversized",
+          "슬림핏, slimfit, 타이트핏, 스키니",
+
+          "티셔츠, 티, t-shirt, tee, 반팔",
+          "맨투맨, mtm, 스웨트셔츠, sweatshirt",
+          "후드티, 후드, 후디, hoodie, hood",
+          "니트, knit, 스웨터, sweater",
+          "가디건, cardigan, 아우터",
+          "롱슬리브, long sleeve, 긴팔티, 긴팔, 쭉티",
+          "폴로셔츠, polo, 카라티",
+
+          "바지, 팬츠, pants, 하의, 트라우저",
+          "슬랙스, slacks, 정장바지, 수트팬츠",
+          "청바지, jeans, 데님팬츠, 진",
+          "면바지, 치노팬츠, chino, cotton pants",
+          "반바지, 쇼츠, shorts, short pants, 핫팬츠",
+          "조거팬츠, 조거, jogger",
+          "트레이닝팬츠, 트레이닝복, 츄리닝, 운동복, sweat pants",
+          "레깅스, leggings, 쫄바지"
         ],
         "lenient": true
       }

--- a/main-service/src/main/resources/elasticsearch/products-settings.json
+++ b/main-service/src/main/resources/elasticsearch/products-settings.json
@@ -1,0 +1,51 @@
+{
+  "analysis": {
+    "analyzer": {
+      "nori_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer",
+        "filter": ["lowercase"]
+      },
+      "edge_ngram_analyzer": {
+        "type": "custom",
+        "tokenizer": "edge_ngram_tokenizer",
+        "filter": ["lowercase"]
+      },
+      "nori_synonym_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer",
+        "filter": ["lowercase", "synonym_filter"]
+      }
+    },
+    "tokenizer": {
+      "nori_tokenizer": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "mixed"
+      },
+      "edge_ngram_tokenizer": {
+        "type": "edge_ngram",
+        "min_gram": 1,
+        "max_gram": 20,
+        "token_chars": ["letter", "digit"]
+      }
+    },
+    "filter": {
+      "synonym_filter": {
+        "type": "synonym_graph",
+        "synonyms": [
+          "삼성,샘숭,삼송,samsung",
+          "lg,엘지,앨지,엘쥐,앨쥐",
+          "바지, 팬츠, pants, 슬랙스, 조거팬츠, 레깅스, 하의"
+        ],
+        "lenient": true
+      }
+    },
+    "normalizer": {
+      "lowercase_normalizer": {
+        "type": "custom",
+        "filter": ["lowercase"]
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #192 

---

## 🧩 구현한 기능
- [x] ELS에 반영할 수 있도록 CUD 구현
- [x] 상품 검색
- [x] 자동 완성

1. 상품 검색 
    -  카테고리를 핵심 기준으로 하고 상품명, 상점명(브랜드)를 검색합니다.
    -  이후 카테고리가 세분화 되면 로직 및 쿼리 변경이 예상됩니다.
2. 자동 완성
    - 상품 검색 시 일부 검색어만 입력해도 이후의 상품명이 출력되도록 합니다.
    - 띄어쓰기를 반영할 수 있도록 합니다.
    - 예 : 나이키 운 -> 나이키 운동복, 나이키 운동화 등

---

## 🔄 기능 흐름
1. 사용자가 검색어 입력 / 검색 요청
2. 서버에서 ELS에서 적절한 상품을 찾아 리턴 처리
3. 결과를 리스트 형태로 반환

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 로직에서 ELS 반영 CUD 추가
- 상품 등록 서비스 리턴 타입을 void로 수정

### 🗂 구조 변경
- 패키지 구조 변경 여부
- 새로 추가 / 삭제된 클래스
    - productMapper, ProductDocument, ProductElasticRepository, products-settings.json 파일이 추가되었습니다. 

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman / Swagger 테스트
- [x] kibana 테스트

---

## 🔍 리뷰 요청 포인트
- controller에 새로 추가된 url이 적절한 지 확인 부탁드립니다.
- 성능 또는 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] 카테고리 작업 완료 시 해당 코드 반영
- [ ] 검색 성능 개선
- [ ] 자동 완성 성능 개선
- [ ] synonym 수정
