### PR TITLE
order-service 비동기 통신 구현

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 
     // kafka 이벤트 공통 라이브러리
     implementation 'io.codebuddy:common-event:1.0.1'
+    // kafka 비동기 통신
+    implementation 'org.springframework.kafka:spring-kafka'
 
 }
 dependencyManagement {

--- a/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/controller/OrderController.java
+++ b/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/controller/OrderController.java
@@ -57,7 +57,8 @@ public class OrderController {
 
         Long memberId = Long.parseLong(currentUser.userId());
         Long orderId = orderService.createOrder(memberId, request);
-        return ResponseEntity.ok(orderId);
+        // 비동기 처리이므로 ACCEPTED로 상태 변경
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(orderId);
     }
 
     /**

--- a/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/exception/OrderErrorCode.java
@@ -13,7 +13,9 @@ public enum OrderErrorCode {
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 
     // 상품의 재고가 적어 주문할 수 없는 경우 (409 CONFLICT)
-    OUT_OF_STOCK(HttpStatus.CONFLICT, "남은 재고가 없습니다.");
+    OUT_OF_STOCK(HttpStatus.CONFLICT, "남은 재고가 없습니다."),
+
+    CANCEL_NOT_ALLOWED(HttpStatus.CONFLICT, "주문취소 실패");
 
     private final HttpStatus status;
     private final String message;

--- a/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/kafka/OrderEventConsumer.java
+++ b/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/kafka/OrderEventConsumer.java
@@ -1,0 +1,99 @@
+package io.codebuddy.closetbuddy.domain.orders.kafka;
+
+import io.codebuddy.closetbuddy.domain.orders.exception.OrderErrorCode;
+import io.codebuddy.closetbuddy.domain.orders.exception.OrderException;
+import io.codebuddy.closetbuddy.domain.orders.model.entity.Order;
+import io.codebuddy.closetbuddy.domain.orders.repository.OrderRepository;
+import io.codebuddy.closetbuddy.event.*;
+import io.codebuddy.closetbuddy.global.config.enumfile.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventConsumer {
+    private final OrderRepository orderRepository;
+    private final OrderEventProducer orderEventProducer;
+    /**
+     * main-service로부터 재고 확인 결과 수신
+     * 성공 시 STOCK_CONFIRMED으로 상태 변경, 결제 요청 발행
+     * 실패 시 FAILED로 상태 변경 (보상 불필요)
+     */
+    @KafkaListener(topics = "order.stock-check.result", groupId = "order-service-group")
+    @Transactional
+    public void handleStockCheckResult(StockCheckResult result) {
+        log.info("재고 확인 결과 수신: orderId={}, success={}", result.orderId(), result.success());
+        Order order = orderRepository.findById(result.orderId())
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+        if (result.success()) {
+            // 재고 차감 성공 -> 결제 요청
+            order.changeStatus(OrderStatus.STOCK_CONFIRMED);
+            // OrderItem → OrderItemRequest 변환
+            List<PaymentRequestEvent.OrderItemRequest> itemRequests =
+                    order.getOrderItem().stream()
+                            .map(oi -> new PaymentRequestEvent.OrderItemRequest(
+                                    oi.getOrderItemId(),
+                                    oi.getSellerId(),
+                                    oi.getStoreId(),
+                                    oi.getProductId(),
+                                    oi.getOrderCount(),
+                                    oi.getOrderPrice(),
+                                    oi.getProductName(),
+                                    oi.getStoreName(),
+                                    oi.getSellerName()
+                            ))
+                            .toList();
+            PaymentRequestEvent paymentRequest = new PaymentRequestEvent(
+                    order.getOrderId(),
+                    order.getMemberId(),
+                    order.getOrderAmount(),
+                    itemRequests
+            );
+            orderEventProducer.sendPaymentRequest(paymentRequest);
+            log.info("결제 요청 발행 완료: orderId={}, amount={}",
+                    order.getOrderId(), order.getOrderAmount());
+        } else {
+            // 재고 부족 -> 주문 실패 (보상 트랜잭션 불필요)
+            order.changeStatus(OrderStatus.FAILED);
+            log.warn("주문 실패 (재고 부족): orderId={}, reason={}",
+                    result.orderId(), result.failReason());
+        }
+    }
+    /**
+     * payment-service로부터 결제 결과 수신
+     * 성공 시 PAID -> COMPLETED
+     * 실패 시 FAILED 상태변경 + 재고 롤백 발행 (보상 트랜잭션 수행)
+     */
+    @KafkaListener(topics = "order.payment.result", groupId = "order-service-group")
+    @Transactional
+    public void handlePaymentResult(PaymentResultEvent result) {
+        log.info("결제 결과 수신: orderId={}, success={}", result.orderId(), result.success());
+        Order order = orderRepository.findById(result.orderId())
+                .orElseThrow(() -> new RuntimeException(
+                        "주문을 찾을 수 없습니다: orderId=" + result.orderId()));
+        if (result.success()) {
+            // 결제 성공 -> 주문 완료
+            order.changeStatus(OrderStatus.COMPLETED);
+            log.info("주문 완료: orderId={}", result.orderId());
+        } else {
+            // 결제 실패 -> 주문 실패 + 재고 롤백 (보상 트랜잭션수행)
+            order.changeStatus(OrderStatus.FAILED);
+            // 재고 롤백을 위해 OrderItem -> StockItem 변환
+            List<StockItem> stockItems = order.getOrderItem().stream()
+                    .map(oi -> new StockItem(oi.getProductId(), oi.getOrderCount()))
+                    .toList();
+            StockRollbackRequest rollbackRequest = new StockRollbackRequest(
+                    order.getOrderId(), stockItems
+            );
+            orderEventProducer.sendStockRollback(rollbackRequest);
+            log.warn("주문 실패 (결제 실패): orderId={}, reason={}. 재고 롤백 발행됨.",
+                    result.orderId(), result.failReason());
+        }
+    }
+}

--- a/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/kafka/OrderEventProducer.java
+++ b/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/kafka/OrderEventProducer.java
@@ -1,0 +1,52 @@
+package io.codebuddy.closetbuddy.domain.orders.kafka;
+
+import io.codebuddy.closetbuddy.event.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    /**
+     * 재고 확인 이벤트 발행
+     * 재고 확인 성공 후 호출
+     */
+    public void sendStockCheckRequest(StockCheckRequest request) {
+        log.info("재고 확인 요청 발행: orderId={}", request.orderId());
+        kafkaTemplate.send("order.stock-check.request", request);
+
+    }
+
+    /**
+     * 결제 요청 이벤트 발행
+     * 재고 확인 성공 후 호출
+     */
+    public void sendPaymentRequest(PaymentRequestEvent request) {
+        log.info("결제 요청 발행: orderId={}", request.orderId());
+        kafkaTemplate.send("order.payment.request", request);
+    }
+
+    /**
+     * 재고 롤백 이벤트 발행
+     * 결제 실패/주문 실패 시 호출되어 보상 트랜잭션 수행
+     */
+    public void sendStockRollback(StockRollbackRequest request) {
+        log.info("재고 롤백 발행: orderId={}", request.orderId());
+        kafkaTemplate.send("order.stock.rollback", request);
+    }
+
+    /**
+     * 결제 롤백 이벤트 발행
+     * PAID 상태에서 주문 취소 시 호출되어 보상 트랜잭션 수행
+     */
+    public void sendPaymentRollback(PaymentRollbackRequest request) {
+        log.info("결제 롤백 발행: orderId={}", request.orderId());
+        kafkaTemplate.send("order.payment.rollback", request);
+    }
+}

--- a/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/service/OrderService.java
+++ b/order-service/src/main/java/io/codebuddy/closetbuddy/domain/orders/service/OrderService.java
@@ -2,7 +2,12 @@ package io.codebuddy.closetbuddy.domain.orders.service;
 
 
 import io.codebuddy.closetbuddy.domain.carts.model.dto.request.CartDeleteRequest;
+import io.codebuddy.closetbuddy.domain.orders.kafka.OrderEventProducer;
 import io.codebuddy.closetbuddy.domain.orders.model.dto.response.*;
+import io.codebuddy.closetbuddy.event.PaymentRollbackRequest;
+import io.codebuddy.closetbuddy.event.StockCheckRequest;
+import io.codebuddy.closetbuddy.event.StockItem;
+import io.codebuddy.closetbuddy.event.StockRollbackRequest;
 import lombok.RequiredArgsConstructor;
 import io.codebuddy.closetbuddy.domain.carts.exception.CartErrorCode;
 import io.codebuddy.closetbuddy.domain.carts.exception.CartException;
@@ -31,6 +36,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final CartService cartService;
     private final CatalogServiceClient catalogServiceClient;
+    private final OrderEventProducer orderEventProducer;
 
     /**
      * 주문을 생성합니다.
@@ -48,6 +54,7 @@ public class OrderService {
         }
 
         List<OrderItem> orderItems = new ArrayList<>();
+        List<StockItem> stockItems = new ArrayList<>();
 
         // 요청 받은 Dto의 orderItems 를 꺼내 주문 생성 Dto에 옮겨 담습니다.
         for (OrderItemCreateRequestDto itemDto : requestDto.orderItems()) {
@@ -66,11 +73,26 @@ public class OrderService {
                     response.productPrice(), // 상품 가격
                     itemDto.orderCount() // 주문 수량
             ));
+
+            // 재고 확인을 위한 StockItem 생성
+            stockItems.add(new StockItem(
+                    itemDto.productId(),
+                    itemDto.orderCount()
+            ));
         }
 
         // 새로운 주문 객체에 orderItem을 저장합니다.
         Order order = Order.createOrder(memberId, orderItems);
         orderRepository.save(order);
+
+        // 재고 확인 요청 이벤트 발행
+        StockCheckRequest stockCheckRequest = new StockCheckRequest(
+                order.getOrderId(),
+                memberId,
+                stockItems
+        );
+
+        orderEventProducer.sendStockCheckRequest(stockCheckRequest);
 
         // 생성된 주문 아이디를 반환합니다.
         return order.getOrderId();
@@ -221,13 +243,41 @@ public class OrderService {
      */
     @Transactional
     public void cancelOrder(Long memberId, Long orderId) {
-
-        // 주문 ID를 통해 삭제할 주문 내역이 없으면 주문을 찾을 수 없다는 예외를 반환해줍니다.
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
+        OrderStatus currentStatus = order.getOrderStatus();
         order.changeStatus(OrderStatus.CANCELED);
+
+        // 상태별 보상 트랜잭션
+        switch (currentStatus) {
+            case PAID, COMPLETED -> {
+                // 결제 + 재고 모두 롤백
+                orderEventProducer.sendPaymentRollback(
+                        new PaymentRollbackRequest(orderId, memberId)
+                );
+                List<StockItem> stockItems = order.getOrderItem().stream()
+                        .map(orderItem -> new StockItem(orderItem.getProductId(), orderItem.getOrderCount()))
+                        .toList();
+                orderEventProducer.sendStockRollback(
+                        new StockRollbackRequest(orderId, stockItems)
+                );
+            }
+            case STOCK_CONFIRMED -> {
+                // 재고만 롤백
+                List<StockItem> stockItems = order.getOrderItem().stream()
+                        .map(orderItem -> new StockItem(orderItem.getProductId(), orderItem.getOrderCount()))
+                        .toList();
+                orderEventProducer.sendStockRollback(
+                        new StockRollbackRequest(orderId, stockItems)
+                );
+            }
+            case CREATED -> {
+            }
+            default -> throw new OrderException(OrderErrorCode.CANCEL_NOT_ALLOWED);
+        }
     }
+
 
     @Transactional(readOnly = true)
     public InternalOrderResponse getInternalOrder(Long orderId){

--- a/order-service/src/main/java/io/codebuddy/closetbuddy/global/config/enumfile/OrderStatus.java
+++ b/order-service/src/main/java/io/codebuddy/closetbuddy/global/config/enumfile/OrderStatus.java
@@ -2,7 +2,9 @@ package io.codebuddy.closetbuddy.global.config.enumfile;
 
 public enum OrderStatus {
     CREATED,
-    PAID,
-    CANCELED,
-    COMPLETED
+    STOCK_CONFIRMED, //재고 차감 롤백 판단에 필요
+    PAID,//예치금 차감 여부 판단, 예치금 차감 롤백 판단에 필요
+    CANCELED, //주문 취소
+    COMPLETED, //주문 완료
+    FAILED //주문 실패
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #219

---

## 🧩 구현한 기능
- [x] kafka 공통 이벤트 라이브러리 종속성 주입
- [x] 원활한 비동기 통신을 위한 order status 확장
- [x] kafka producer/consumer 구현
- [x] 이미 구현된 product 발행 이벤트와 통신
- [ ] catalog service와 payment service간 비동기 통신 orchestration 로직 수행

---

## 🔄 기능 흐름
1. 사용자가 주문 요청
2. order-service가 주문 생성 이벤트 발행
3. catalog-service에서 이벤트를 수신하여 재고 확인후 차감
4. 차감 결과를 order-service가 수신하여 결제 이벤트 발행
5. 결제 서비스에서 결제 수행 후 완료시 결제 완료 이벤트 발행
6. order-service에서 이벤트 수신후 주문완료 상태 변경
7. 중간 과정 문제시 보상트랜잭션 수행

---

## ✨ 변동 사항
### 🔧 코드 변경
- orderStatus 확장
- orderService 주문 생성/ 삭제 로직 수정
- 비동기 통신을 위한 common-event라이브러리 의존

### 🗂 구조 변경
- Order-service Kafka 패키지 추가
- 이벤트 producer/consumer 추가

---

## 🧪 테스트 방법
- [ ] 로컬 테스트 완료
- [ ] Postman

---

## 🔍 리뷰 요청 포인트
- order-service가 주문-재고차감-결제 플로우를 제어하도록 잘 설계되었는지 검토 부탁드립니다.
- producer와 consumer 메서드가 빠짐없이 작성되었는지 위주로 검토바랍니다.

---

## 🚀 예상 추가 작업
- [ ] 예외 처리 보완
- [ ] 테스트 코드 보강
