### PR TITLE
공통 라이브러리 GitHub Packages 자동 배포

### DIFF
--- a/.github/workflows/publish-common-event.yml
+++ b/.github/workflows/publish-common-event.yml
@@ -1,0 +1,39 @@
+name: Publish common-event
+
+on:
+  push:
+    branches: [ main, closetBuddy-MSA-dev ]
+    paths:
+      - 'common-event/**'          # common-event 디렉토리가 변경될 때 실행
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write #Github pakages에 쓰기권한 부여
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4 #actions version-4
+        with:
+          # 프로젝트 JDK 버전과 동일하게 17버전 사용
+          java-version: '17'
+          distribution: 'temurin'
+
+      # gradlew 실행권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        working-directory: common-event
+
+      # GitHub Pakages에 배포
+      - name: Publish to GitHub Packages
+        run: ./gradlew publish
+        working-directory: common-event
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/common-event/build.gradle
+++ b/common-event/build.gradle
@@ -13,4 +13,14 @@ publishing {
             from components.java
         }
     }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/https://github.com/prgrms-be-adv-devcourse/beadv3_3_CodeBuddy_BE")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }

--- a/main-service/build.gradle
+++ b/main-service/build.gradle
@@ -20,6 +20,16 @@ java {
 repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/https://github.com/prgrms-be-adv-devcourse/beadv3_3_CodeBuddy_BE")
+        credentials {
+            // 로컬에서 빌드할때에는 gradle.properties 에서 gpr.user을 찾아 username으로 사용
+            // Github Actions에서 CI 빌드시에는 GitHub Actions가 넣은 GITHUB_ACTOR를 사용
+            username = project.findProperty("gpr.usr") ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
 }
 
 dependencies {

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -20,6 +20,16 @@ java {
 repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/https://github.com/prgrms-be-adv-devcourse/beadv3_3_CodeBuddy_BE")
+        credentials {
+            // 로컬에서 빌드할때에는 gradle.properties 에서 gpr.user을 찾아 username으로 사용
+            // Github Actions에서 CI 빌드시에는 GitHub Actions가 넣은 GITHUB_ACTOR를 사용
+            username = project.findProperty("gpr.usr") ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
 }
 
 dependencies {

--- a/pay-service/build.gradle
+++ b/pay-service/build.gradle
@@ -25,6 +25,17 @@ configurations {
 
 repositories {
     mavenCentral()
+    mavenLocal()
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/https://github.com/prgrms-be-adv-devcourse/beadv3_3_CodeBuddy_BE")
+        credentials {
+            // 로컬에서 빌드할때에는 gradle.properties 에서 gpr.user을 찾아 username으로 사용
+            // Github Actions에서 CI 빌드시에는 GitHub Actions가 넣은 GITHUB_ACTOR를 사용
+            username = project.findProperty("gpr.usr") ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #229

---

## 🧩 구현한 기능
- [x] 공통라이브러리를 CI 스크립트를 통한 자동 빌드시에도 읽어올 수 있도록 GitHub Pakages를 통한 자동 배포
- [x] GitHub Pakages를 통해 자동 배포된 라이브러리를 원격지에서 읽어올 수 있도록 서비스별 라이브러리 repository 추가

---

## 🔄 기능 흐름
1. CI 스크립트를 통해 변경 서비스 자동 빌드 시도
2. 빌드시 GitHub Packages를 통해 배포된 공통 라이브러리를 찾아 빌드
3. CI를 통한 빌드시에도 각 서비스가 정상적으로 공통 라이브러리 종속

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 로컬에서 MavenLocal repository에서 공통 라이브러리를 찾아 빌드하는 방식에서 Github Packages를 통해 라이브러리/서비스 모두 자동 빌드+배포

### 🗂 구조 변경
- common-event또한 버전 업데이트시 Github Packages를 통해 자동 빌드+배포되어 버전관리 또한 자동으로 이루어짐

---

## 🧪 테스트 방법
- [ ] 서비스 CI 스크립트 작업 완료 후 테스트 필요

---

## 🔍 리뷰 요청 포인트
- common-event 변경시 자동으로 버전 업데이트가 이루어지도록 publish 스크립트가 잘 작되었는지 검토 부탁드립니다.
- 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] 서비스 CI 스크립트 작성/GitHub Actions를 통한 자동 배포 구축
- [ ] CI를 통해서도 라이브러리 의존 유지 테스트
