### PR TITLE
[#236] Swagger 인증 헤더 토큰 부재 문제 해결 : pay-service

### DIFF
--- a/pay-service/src/main/java/io/codebuddy/payservice/domain/common/config/WebMvcConfig.java
+++ b/pay-service/src/main/java/io/codebuddy/payservice/domain/common/config/WebMvcConfig.java
@@ -3,6 +3,7 @@ package io.codebuddy.payservice.domain.common.config;
 import io.codebuddy.payservice.domain.common.web.CurrentUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -19,5 +20,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentUserArgumentResolver);
+    }
+
+    // CORS 설정을 통해 Swagger에서의 접근 허용
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/pay-service/src/main/java/io/codebuddy/payservice/domain/global/config/SwaggerConfig.java
+++ b/pay-service/src/main/java/io/codebuddy/payservice/domain/global/config/SwaggerConfig.java
@@ -1,0 +1,56 @@
+package io.codebuddy.payservice.domain.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        // Bearer Token 설정
+                        .addSecuritySchemes("Bearer Token",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT"))
+
+                        // X-USER-ID 헤더 설정
+                        .addSecuritySchemes("user-id",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("X-USER-ID")
+                                        .description("Gateway에서 주입되는 User ID (예: 1)"))
+
+                        // X-USER-ROLE 헤더 설정
+                        .addSecuritySchemes("user-role",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("X-USER-ROLE")
+                                        .description("Gateway에서 주입되는 User Role (예: MEMBER)")))
+
+                // 3가지 설정을 모든 API에 전역으로 적용
+                .addSecurityItem(new SecurityRequirement()
+                        .addList("bearer-key")
+                        .addList("user-id")
+                        .addList("user-role"))
+
+                .info(new Info()
+                        .title("Pay Service API")
+                        .description("Pay Service API 명세서")
+                        .version("v0"));
+    }
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #236 

- [Swagger 인증 헤더 토큰 문제 - Notion](https://www.notion.so/Swagger-30915a01205480e089f4fbe12d81ef18?v=2db15a012054810e9efd000ca9464ebe&source=copy_link)
---

## 🧩 구현한 기능
- [x] Swagger 에서 Bearer Token 입력 허용
- [x] Token에 X-CODE 추가
- [x] CORS 허용 

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

swagger에서 Try it out으로 api 테스트를 진행하면 인증 헤더 토큰 부재로 api 응답을 확인할 수 없던 문제가 있었습니다.
해당 문제를 해결하고자 아래의 해결 과정을 거쳤습니다.
추가적인 내용은 위의 노션 링크 확인 바랍니다.

1. `SwaggerConfig`를 작성하여 api 요청 시 Bearer Token을 전달할 수 있도록 함.
2. 브라우저 상에서 보안 정책으로 API응답을 차단하는 문제가 보여 Spring MVC 설정에서 CORS 허용 변경
3. 토큰의 X-CODE 부재를 해결하기 위해 추가적으로 `SwaggerConfig` 에 추가할 수 있도록 변경

현재 user-service도 swagger가 동작하지 않기 때문에 postman으로 로그인 하고 access token을 swagger에 입력하였습니다.

### Token 및 X-CODE 입력 부분
<img width="1919" height="829" alt="image" src="https://github.com/user-attachments/assets/facac20d-7945-4f44-93ce-69cd88272600" />

### api 테스트 성공한 모습
<img width="1374" height="839" alt="image" src="https://github.com/user-attachments/assets/dfaf68eb-5547-4f81-bd40-8f9002af31f0" />


---

## ✨ 변동 사항
### 🔧 코드 변경
`global.config.SwaggerConfig` 추가
`common.config.WebMvcConfig` 변경

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman / Swagger 테스트

postman과 Swagger에서 pay-service 모든 부분이 정상 동작하는 부분 확인하였습니다.

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한 지 확인 부탁드립니다.
- **CORS 허용 부분이 적절한 지 확인 부탁드립니다.**

---

## 🚀 예상 추가 작업
- [ ] 다른 서비스에 해당 작업 적용
