### PR TITLE
CI 파이프라인을 통한 자동 빌드를 위한 테스트 코드 수정작업

### DIFF
--- a/main-service/build.gradle
+++ b/main-service/build.gradle
@@ -42,6 +42,12 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     //feign-client
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    //test 환경 구성
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:elasticsearch'
+    testImplementation 'org.testcontainers:kafka'
+    testImplementation 'org.testcontainers:mysql'
 
     //lombok
     compileOnly 'org.projectlombok:lombok'

--- a/main-service/src/test/java/io/codebuddy/closetbuddy/ClosetBuddyApplicationTests.java
+++ b/main-service/src/test/java/io/codebuddy/closetbuddy/ClosetBuddyApplicationTests.java
@@ -2,12 +2,57 @@ package io.codebuddy.closetbuddy;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
 class ClosetBuddyApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
+        // mysql 컨테이너
+        @Container
+        @ServiceConnection
+        static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
+
+        // Redis 컨테이너
+        @Container
+        @ServiceConnection
+        static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:latest"))
+                        .withExposedPorts(6379);
+
+        // kafka 컨테이너
+        @Container
+        @ServiceConnection
+        static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.4.4"));
+
+        // els
+        @Container
+        @ServiceConnection
+        // 형태소 분석이미지 그대로 테스트에 활용
+        static ElasticsearchContainer elasticsearch = new ElasticsearchContainer(
+                        DockerImageName.parse("ghcr.io/eddie1031/es:latest")
+                                        .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
+
+                        // docker compose 파일을 참고하여 개발 환경과 똑같은 환경 구성으로 띄움
+                        // 단일 노드 모드 설정
+                        .withEnv("discovery.type", "single-node")
+                        // 보안 기능 비활성화
+                        .withEnv("xpack.security.enabled", "false")
+                        // ssl 인증 비활성화
+                        .withEnv("xpack.security.http.ssl.enabled", "false")
+                        // jvm 메모리 설정
+                        .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
+
+        @Test
+        void contextLoads() {
+        }
 
 }

--- a/main-service/src/test/java/io/codebuddy/closetbuddy/ClosetBuddyApplicationTests.java
+++ b/main-service/src/test/java/io/codebuddy/closetbuddy/ClosetBuddyApplicationTests.java
@@ -22,7 +22,7 @@ class ClosetBuddyApplicationTests {
         @ServiceConnection
         static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
 
-        // Redis 컨테이너
+        // Rdis 컨테이너
         @Container
         @ServiceConnection
         static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:latest"))
@@ -31,25 +31,14 @@ class ClosetBuddyApplicationTests {
         // kafka 컨테이너
         @Container
         @ServiceConnection
-        static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.4.4"));
+        // test환경에 적합한 confluentinc이미지 사용하도록 명시
+        static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"));
 
         // els
         @Container
         @ServiceConnection
-        // 형태소 분석이미지 그대로 테스트에 활용
         static ElasticsearchContainer elasticsearch = new ElasticsearchContainer(
-                        DockerImageName.parse("ghcr.io/eddie1031/es:latest")
-                                        .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
-
-                        // docker compose 파일을 참고하여 개발 환경과 똑같은 환경 구성으로 띄움
-                        // 단일 노드 모드 설정
-                        .withEnv("discovery.type", "single-node")
-                        // 보안 기능 비활성화
-                        .withEnv("xpack.security.enabled", "false")
-                        // ssl 인증 비활성화
-                        .withEnv("xpack.security.http.ssl.enabled", "false")
-                        // jvm 메모리 설정
-                        .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
+                        DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:7.17.10"));
 
         @Test
         void contextLoads() {

--- a/main-service/src/test/java/io/codebuddy/closetbuddy/ClosetBuddyApplicationTests.java
+++ b/main-service/src/test/java/io/codebuddy/closetbuddy/ClosetBuddyApplicationTests.java
@@ -22,7 +22,7 @@ class ClosetBuddyApplicationTests {
         @ServiceConnection
         static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
 
-        // Rdis 컨테이너
+        // Redis 컨테이너
         @Container
         @ServiceConnection
         static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:latest"))

--- a/main-service/src/test/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductServiceTest.java
+++ b/main-service/src/test/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductServiceTest.java
@@ -1,6 +1,5 @@
 package io.codebuddy.closetbuddy.domain.catalog.products.service;
 
-import io.codebuddy.closetbuddy.domain.catalog.category.exception.CategoryErrorCode;
 import io.codebuddy.closetbuddy.domain.catalog.category.exception.CategoryException;
 import io.codebuddy.closetbuddy.domain.catalog.category.model.entity.Category;
 import io.codebuddy.closetbuddy.domain.catalog.products.exception.ProductErrorCode;
@@ -226,7 +225,7 @@ class ProductServiceTest {
 
         @Test
         @DisplayName("정상 수정 시 상품 및 ELS 업데이트")
-        void updateProduct_성공() {
+        void updateProduct_success() {
 
             Long memberId = 1L;
             Long productId = 300L;
@@ -272,7 +271,7 @@ class ProductServiceTest {
 
         @Test
         @DisplayName("비소유자가 수정하면 NOT_OWNER 예외")
-        void updateProduct_비소유자_예외() {
+        void updateProduct_NOT_OWNER_exception() {
 
             Long otherMemberId = 999L;
             Long productId = 300L;

--- a/main-service/src/test/resources/data.sql
+++ b/main-service/src/test/resources/data.sql
@@ -1,30 +1,30 @@
--- 테스트용 카테고리 데이터 (H2 호환)
--- MERGE INTO를 사용하여 중복 삽입 방지
+-- 테스트용 카테고리 데이터 (단위테스트용 H2 db와 통합테스트 환경 MySQL db 모두 삽입되도록 수정)
+-- INSERT IGNORE INTO를 사용하여 중복 삽입 방지
 
 -- 루트 카테고리
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (1, '상의', 'TOP', NULL);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (2, '하의', 'PANTS', NULL);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (1, '상의', 'TOP', NULL);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (2, '하의', 'PANTS', NULL);
 
 -- 상의 하위 카테고리
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (3, '티셔츠', 'TSHIRT', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (4, '셔츠', 'SHIRT', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (5, '맨투맨', 'SWEATSHIRT', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (6, '후드티', 'HOODIE', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (7, '니트', 'KNIT', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (8, '가디건', 'CARDIGAN', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (9, '베스트', 'VEST', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (10, '폴로셔츠', 'POLO', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (11, '블라우스', 'BLOUSE', 1);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (12, '롱슬리브', 'LONGSLEEVE', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (3, '티셔츠', 'TSHIRT', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (4, '셔츠', 'SHIRT', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (5, '맨투맨', 'SWEATSHIRT', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (6, '후드티', 'HOODIE', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (7, '니트', 'KNIT', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (8, '가디건', 'CARDIGAN', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (9, '베스트', 'VEST', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (10, '폴로셔츠', 'POLO', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (11, '블라우스', 'BLOUSE', 1);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (12, '롱슬리브', 'LONGSLEEVE', 1);
 
 -- 하의 하위 카테고리
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (13, '슬랙스', 'SLACKS', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (14, '청바지', 'JEANS', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (15, '면바지', 'COTTON_PANTS', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (16, '조거팬츠', 'JOGGERS', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (17, '카고팬츠', 'CARGO', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (18, '치노팬츠', 'CHINOS', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (19, '반바지', 'SHORTS', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (20, '레깅스', 'LEGGINGS', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (21, '스커트', 'SKIRT', 2);
-MERGE INTO category (category_id, name, code, parent_id) KEY (category_id) VALUES (22, '트레이닝팬츠', 'TRAINING', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (13, '슬랙스', 'SLACKS', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (14, '청바지', 'JEANS', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (15, '면바지', 'COTTON_PANTS', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (16, '조거팬츠', 'JOGGERS', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (17, '카고팬츠', 'CARGO', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (18, '치노팬츠', 'CHINOS', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (19, '반바지', 'SHORTS', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (20, '레깅스', 'LEGGINGS', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (21, '스커트', 'SKIRT', 2);
+INSERT IGNORE INTO category (category_id, name, code, parent_id) VALUES (22, '트레이닝팬츠', 'TRAINING', 2);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #234

---

## 🧩 구현한 기능
- [ ] 단위 테스트 및 통합테스트시 계층형 카테고리가 적용될 수 있도록 sql 쿼리문 보완
- [ ] 통합테스트시 외부 인프라 컨테이너를 통해 테스트빌드 할 수 있도록 수정

---

## 🔄 기능 흐름
1. CI 파이프라인을 통해 테스트코드(단위테스트/통합테스트) 수행
2. CI 서버에서 통합테스트시 컨테이너를 통해 외부 인프라 테스트
3. 테스트 성공시 CI 파이프라인을 통한 자동 빌드 수행

---

## ✨ 변동 사항
### 🔧 코드 변경
- 컨텍스트 로드를 포함한 통합테스트에서 인프라 컨테이너를 통해 테스트하도록 변경
- 통합테스트시 계층형 카테고리 데이터 삽입을 mysql db에서도 수행될 수 있도록 쿼리문 보완

### 🗂 구조 변경
- 패키지 및 클래스 추가/제거 없음

---

## 🧪 테스트 방법
- [ ] 로컬 테스트 완료
- [ ] 통합테스트 추가

---

## 🔍 리뷰 요청 포인트
- CI 파이프라인을 통해 단위테스트 및 통합테스트가 잘 수행되는지 검토바랍니다.
- 통합테스트 수행 시 CI 서버에서 외부 인프라 컨테이너를 통해 정상적으로 테스트가 수행되는지 확인 바랍니다.
- 통합테스트시 mysql 컨테이너를 통해 정상적으로 초기 데이터가 삽입되는지 체크 부탁드립니다.

---

## 🚀 예상 추가 작업
- [ ] CI 파이프라인 구축
- [ ] 테스트 코드 보강
