### PR TITLE
[#239] 상품 카테고리 추가에 따른 ELS 검색 쿼리 성능 향상

### DIFF
--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
@@ -262,8 +262,8 @@ public class ProductController {
 
     /*
     상품 검색
-    기본 검색 : http://localhost:8090/product/search?keyword=나이키
-    페이징 : http://localhost:8090/product/search?keyword=나이키&page=0&size=10
+    기본 검색 : http://localhost:8090/api/v1/catalog/products/search?keyword=나이키
+    페이징 : http://localhost:8090/api/v1/catalog/products/search?keyword=나이키&page=0&size=10
      */
     @Operation(
             summary = "상품 검색",

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
@@ -262,8 +262,8 @@ public class ProductController {
 
     /*
     상품 검색
-    기본 검색 : http://localhost:8080/product/search?keyword=나이키
-    페이징 : http://localhost:8080/product/search?keyword=나이키&page=0&size=10
+    기본 검색 : http://localhost:8090/product/search?keyword=나이키
+    페이징 : http://localhost:8090/product/search?keyword=나이키&page=0&size=10
      */
     @Operation(
             summary = "상품 검색",

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
@@ -252,7 +252,7 @@ public class ProductController {
     })
     @GetMapping("/suggestions")
     public ResponseEntity<List<String>> fetchSuggestions(
-            @RequestParam("prefix") String prefix,
+            @RequestParam String prefix,
             @RequestParam(value = "limit", defaultValue = "10") Integer limit
     ) {
         List<String> suggestions = productService.getSuggestions(prefix, limit);
@@ -277,10 +277,31 @@ public class ProductController {
     })
     @GetMapping("/products/search")
     public ResponseEntity<Page<ProductSearchResponse>> searchProducts(
-            @RequestParam(name = "keyword") String keyword,
+            @RequestParam String keyword,
             @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<ProductSearchResponse> result = productService.searchProducts(keyword, pageable);
+
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(
+            summary = "카테고리 기반 상품 검색",
+            description = "카테고리를 선택한 후 관련 상품을 검색합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "검색 성공"
+            )
+    })
+    @GetMapping("/category/{categoryName}")
+    public ResponseEntity<Page<ProductSearchResponse>> searchProducts(
+            @PathVariable String categoryName,
+            @RequestParam String keyword,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        Page<ProductSearchResponse> result = productService.searchProductsByCategoryAndKeyword(categoryName,keyword,pageable);
 
         return ResponseEntity.ok(result);
     }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/controller/ProductController.java
@@ -298,7 +298,7 @@ public class ProductController {
     @GetMapping("/category/{categoryName}")
     public ResponseEntity<Page<ProductSearchResponse>> searchProducts(
             @PathVariable String categoryName,
-            @RequestParam String keyword,
+            @RequestParam(required = false) String keyword,
             @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<ProductSearchResponse> result = productService.searchProductsByCategoryAndKeyword(categoryName,keyword,pageable);

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductMapper.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductMapper.java
@@ -11,8 +11,9 @@ public class ProductMapper {
                 product.getProductName(),
                 product.getProductPrice(),
                 product.getProductStock(),
-                String.valueOf(product.getCategory()),
-                product.getStore().getStoreName(),
+                String.valueOf(product.getStore().getStoreName()),
+                String.valueOf(product.getCategory().getParent().getCode()),
+                String.valueOf(product.getCategory().getCode()),
                 product.getImageUrl()
         );
 

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductMapper.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductMapper.java
@@ -5,6 +5,21 @@ import io.codebuddy.closetbuddy.domain.catalog.products.model.entity.ProductDocu
 
 public class ProductMapper {
     public static ProductDocument toProductDocument(Product product){
+
+        String topCategoryCode = null;
+        String subCategoryCode = null;
+
+        if (product.getCategory() != null) {
+            if (product.getCategory().getParent() != null) {
+                // 하위 카테고리가 등록된 경우
+                topCategoryCode = String.valueOf(product.getCategory().getParent().getCode());
+                subCategoryCode = String.valueOf(product.getCategory().getCode());
+            } else {
+                // 부모 카테고리만 등록된 경우
+                topCategoryCode = String.valueOf(product.getCategory().getCode());
+            }
+        }
+
         return new ProductDocument(
 
                 String.valueOf(product.getProductId()),
@@ -12,8 +27,8 @@ public class ProductMapper {
                 product.getProductPrice(),
                 product.getProductStock(),
                 String.valueOf(product.getStore().getStoreName()),
-                String.valueOf(product.getCategory().getParent().getCode()),
-                String.valueOf(product.getCategory().getCode()),
+                topCategoryCode,
+                subCategoryCode,
                 product.getImageUrl()
         );
 

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductSearchResponse.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/dto/ProductSearchResponse.java
@@ -7,7 +7,8 @@ public record ProductSearchResponse(
         String productName,
         Long productPrice,
         int productStock,
-        String categoryName,      // 카테고리명
+        String topCategory,
+        String subCategory,
         String storeName
 ) {
     // document -> productResponse
@@ -17,7 +18,8 @@ public record ProductSearchResponse(
                 doc.getProductName(),
                 doc.getProductPrice(),
                 doc.getProductStock(),
-                doc.getCategoryName(),
+                doc.getTopCategory(),
+                doc.getSubCategory(),
                 doc.getStoreName()
         );
     }

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
@@ -25,8 +25,6 @@ public class ProductDocument {
             otherFields = {
                     // 부분일치
                     @InnerField(suffix = "ngram", type = FieldType.Text, analyzer = "edge_ngram_analyzer", searchAnalyzer = "nori_synonym_analyzer"),
-                    // 상품명 정렬, 정확히 그 이름인 상품 검색
-                    @InnerField(suffix = "keyword", type = FieldType.Keyword, normalizer = "lowercase_normalizer")
             }
     )
     private String productName;

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
@@ -45,9 +45,23 @@ public class ProductDocument {
     )
     private String storeName;
 
-    // 동의어 설정
-    @Field(type = FieldType.Text, analyzer = "nori_synonym_analyzer")
-    private String categoryName;
+    // 상위 카테고리
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "nori_synonym_analyzer"),
+            otherFields = {
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword)
+            }
+    )
+    private String topCategory;
+
+    // 하위 카테고리
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "nori_synonym_analyzer"),
+            otherFields = {
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword)
+            }
+    )
+    private String subCategory;
 
     // 이미지를 검색할 필요 없으므로 색인 제외 (저장 공간 절약)
     @Field(type = FieldType.Keyword, index = false)

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
@@ -25,6 +25,8 @@ public class ProductDocument {
             otherFields = {
                     // 부분일치
                     @InnerField(suffix = "ngram", type = FieldType.Text, analyzer = "edge_ngram_analyzer", searchAnalyzer = "nori_synonym_analyzer"),
+                    // 상품명 정렬, 정확히 그 이름인 상품 검색
+//                    @InnerField(suffix = "keyword", type = FieldType.Keyword, normalizer = "lowercase_normalizer")
             }
     )
     private String productName;

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/model/entity/ProductDocument.java
@@ -49,7 +49,7 @@ public class ProductDocument {
     @MultiField(
             mainField = @Field(type = FieldType.Text, analyzer = "nori_synonym_analyzer"),
             otherFields = {
-                    @InnerField(suffix = "keyword", type = FieldType.Keyword)
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword, normalizer = "lowercase_normalizer")
             }
     )
     private String topCategory;
@@ -58,7 +58,7 @@ public class ProductDocument {
     @MultiField(
             mainField = @Field(type = FieldType.Text, analyzer = "nori_synonym_analyzer"),
             otherFields = {
-                    @InnerField(suffix = "keyword", type = FieldType.Keyword)
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword, normalizer = "lowercase_normalizer")
             }
     )
     private String subCategory;

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/repository/ProductElasticRepository.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/repository/ProductElasticRepository.java
@@ -20,7 +20,7 @@ public interface ProductElasticRepository extends ElasticsearchRepository<Produc
                     "multi_match": {
                         "query": "?0",
                             "fields": [
-                                "subCategory^5",     // 카테고리명 일치 시 가장 상위 노출
+                                "subCategory^5",     // 하위 카테고리 일치 시 가장 상위 노출
                                 "topCategory^3",
                                 "productName^3",
                                 "productName.ngram^2",
@@ -34,6 +34,36 @@ public interface ProductElasticRepository extends ElasticsearchRepository<Produc
     }
     """)
     SearchPage<ProductDocument> searchByKeyword(String keyword, Pageable pageable);
+
+    // 하위 카테고리 내에서 검색 (카테고리 탭을 누른 후 검색했을 때)
+    @Query("""
+    {
+        "bool": {
+            "filter": [
+                {
+                    "term": {
+                        "subCategory.keyword": "?0" // ?0 : 하위 카테고리명
+                    }
+                }
+            ],
+            "must": [
+                {
+                    "multi_match": {
+                        "query": "?1",              // ?1 : 검색 키워드
+                        "fields": [
+                            "productName^3",
+                            "productName.ngram^2",
+                            "storeName"
+                        ],
+                        "type": "best_fields",
+                        "fuzziness": "AUTO"
+                    }
+                }
+            ]
+        }
+    }
+    """)
+    SearchPage<ProductDocument> searchByCategoryAndKeyword(String category, String keyword, Pageable pageable);
 
     // bool_prefix : 띄어쓰기가 포함된 자동완성
     @Query("""

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/repository/ProductElasticRepository.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/repository/ProductElasticRepository.java
@@ -65,6 +65,22 @@ public interface ProductElasticRepository extends ElasticsearchRepository<Produc
     """)
     SearchPage<ProductDocument> searchByCategoryAndKeyword(String category, String keyword, Pageable pageable);
 
+    // 키워드 없이 카테고리만 선택
+    @Query("""
+    {
+        "bool": {
+            "filter": [
+                {
+                    "term": {
+                        "subCategory.keyword": "?0"
+                    }
+                }
+            ]
+        }
+    }
+    """)
+    SearchPage<ProductDocument> searchByCategory(String category, Pageable pageable);
+
     // bool_prefix : 띄어쓰기가 포함된 자동완성
     @Query("""
     {

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/repository/ProductElasticRepository.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/repository/ProductElasticRepository.java
@@ -14,16 +14,22 @@ public interface ProductElasticRepository extends ElasticsearchRepository<Produc
     // fuzziness:  오타 허용 범위
     @Query("""
     {
-        "multi_match": {
-            "query": "?0",
-            "fields": [
-                "productName^3",
-                "productName.ngram^3",
-                "storeName^2",
-                "category"
-            ],
-            "type": "best_fields",
-            "fuzziness": "AUTO"
+        "bool": {
+            "must": [
+                {
+                    "multi_match": {
+                        "query": "?0",
+                            "fields": [
+                                "subCategory^5",     // 카테고리명 일치 시 가장 상위 노출
+                                "topCategory^3",
+                                "productName^3",
+                                "productName.ngram^2",
+                                "storeName^2"],
+                            "type": "best_fields",
+                            "fuzziness": "AUTO"
+                    }
+                }
+            ]
         }
     }
     """)

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
@@ -204,6 +204,26 @@ public class ProductService {
         return new PageImpl<>(responseList, pageable, searchPage.getTotalElements());
     }
 
+    // 하위 카테고리 내에서 검색
+    public Page<ProductSearchResponse> searchProductsByCategoryAndKeyword(String category, String keyword, Pageable pageable) {
+
+        // ELS에서 검색 결과 가져오기
+        SearchPage<ProductDocument> searchPage = productElasticRepository.searchByCategoryAndKeyword(category,keyword,pageable);
+
+        // 결과를 담을 리스트 생성
+        List<ProductSearchResponse> responseList = new ArrayList<>();
+
+        for (SearchHit<ProductDocument> hit : searchPage.getSearchHits()) {
+            ProductDocument document = hit.getContent();
+
+            ProductSearchResponse dto = ProductSearchResponse.fromDocument(document);
+
+            responseList.add(dto);
+        }
+
+        return new PageImpl<>(responseList, pageable, searchPage.getTotalElements());
+    }
+
     // (상점 주인 확인용) 검증 로직
     private void validateStoreOwner(Long memberId, Store store) {
         if (!store.getSeller().getMemberId().equals(memberId)) {

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
@@ -33,6 +33,7 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.SearchPage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -195,9 +196,16 @@ public class ProductService {
     // 하위 카테고리 내에서 검색
     public Page<ProductSearchResponse> searchProductsByCategoryAndKeyword(String category, String keyword, Pageable pageable) {
 
-        // ELS에서 검색 결과 가져오기
-        SearchPage<ProductDocument> searchPage = productElasticRepository.searchByCategoryAndKeyword(category,keyword,pageable);
+        SearchPage<ProductDocument> searchPage;
 
+        // 키워드가 존재하는지 확인
+        if (StringUtils.hasText(keyword)) { // null,공백 확인
+            // 카테고리 선택 후 키워드 검색
+            searchPage = productElasticRepository.searchByCategoryAndKeyword(category, keyword, pageable);
+        } else {
+            // 카테고리만 선택한 경우 (해당 카테고리의 전체 상품 조회)
+            searchPage = productElasticRepository.searchByCategory(category, pageable);
+        }
         return searchToPage(searchPage,pageable);
     }
 

--- a/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
+++ b/main-service/src/main/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductService.java
@@ -189,19 +189,7 @@ public class ProductService {
         // ELS에서 검색 결과 가져오기
         SearchPage<ProductDocument> searchPage = productElasticRepository.searchByKeyword(keyword, pageable);
 
-        // 결과를 담을 리스트 생성
-        List<ProductSearchResponse> responseList = new ArrayList<>();
-
-        for (SearchHit<ProductDocument> hit : searchPage.getSearchHits()) {
-            ProductDocument document = hit.getContent();
-
-            ProductSearchResponse dto = ProductSearchResponse.fromDocument(document);
-
-            responseList.add(dto);
-        }
-
-        // PageImpl로 반환 (데이터 리스트, 페이징 정보, 전체 개수)
-        return new PageImpl<>(responseList, pageable, searchPage.getTotalElements());
+        return searchToPage(searchPage,pageable);
     }
 
     // 하위 카테고리 내에서 검색
@@ -209,6 +197,12 @@ public class ProductService {
 
         // ELS에서 검색 결과 가져오기
         SearchPage<ProductDocument> searchPage = productElasticRepository.searchByCategoryAndKeyword(category,keyword,pageable);
+
+        return searchToPage(searchPage,pageable);
+    }
+
+    // searchPage -> Response 변환
+    private Page<ProductSearchResponse> searchToPage(SearchPage<ProductDocument> searchPage, Pageable pageable) {
 
         // 결과를 담을 리스트 생성
         List<ProductSearchResponse> responseList = new ArrayList<>();

--- a/main-service/src/main/resources/elasticsearch/products-settings.json
+++ b/main-service/src/main/resources/elasticsearch/products-settings.json
@@ -66,10 +66,13 @@
           "슬림핏, slimfit, 타이트핏, 스키니",
 
           "티셔츠, 티, t-shirt, tee, 반팔",
+          "셔츠, shirt, 남방, 와이셔츠, 드레스셔츠",
           "맨투맨, mtm, 스웨트셔츠, sweatshirt",
           "후드티, 후드, 후디, hoodie, hood",
           "니트, knit, 스웨터, sweater",
           "가디건, cardigan, 아우터",
+          "베스트, 조끼, vest, 웨이스트코트, 슬리브리스",
+          "블라우스, blouse, 여성셔츠, 튜닉, 여성남방",
           "롱슬리브, long sleeve, 긴팔티, 긴팔, 쭉티",
           "폴로셔츠, polo, 카라티",
 
@@ -77,6 +80,8 @@
           "슬랙스, slacks, 정장바지, 수트팬츠",
           "청바지, jeans, 데님팬츠, 진",
           "면바지, 치노팬츠, chino, cotton pants",
+          "카고팬츠, cargo, cargo pants, 건빵바지, 유틸리티팬츠",
+          "치노팬츠, 치노, chino",
           "반바지, 쇼츠, shorts, short pants, 핫팬츠",
           "조거팬츠, 조거, jogger",
           "트레이닝팬츠, 트레이닝복, 츄리닝, 운동복, sweat pants",

--- a/main-service/src/test/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductServiceTest.java
+++ b/main-service/src/test/java/io/codebuddy/closetbuddy/domain/catalog/products/service/ProductServiceTest.java
@@ -115,14 +115,15 @@ class ProductServiceTest {
                 .build();
     }
 
-    private ProductDocument createProductDocument(String id, String name, Long price, int stock, String storeName, String categoryName) {
+    private ProductDocument createProductDocument(String id, String name, Long price, int stock, String storeName, String topCategory, String subCategory) {
         return ProductDocument.builder()
                 .id(id)
                 .productName(name)
                 .productPrice(price)
                 .productStock(stock)
                 .storeName(storeName)
-                .categoryName(categoryName)
+                .topCategory(topCategory)
+                .subCategory(subCategory)
                 .imageUrl("https://img.jpg")
                 .build();
     }
@@ -438,9 +439,9 @@ class ProductServiceTest {
             SearchHit<ProductDocument> hit2 = mock(SearchHit.class);
             SearchHit<ProductDocument> hit3 = mock(SearchHit.class);
 
-            ProductDocument nike1 = createProductDocument("1", "나이키 반팔", 10000L, 3, "A상점", "티셔츠");
-            ProductDocument nike2 = createProductDocument("2", "나이키 반팔", 11000L, 4, "B상점", "티셔츠");
-            ProductDocument adidas = createProductDocument("3", "아디다스 반팔", 9000L, 2, "C상점", "티셔츠");
+            ProductDocument nike1 = createProductDocument("1", "나이키 반팔", 10000L, 3, "A상점", "TOP", "TSHIRT" );
+            ProductDocument nike2 = createProductDocument("2", "나이키 반팔", 11000L, 4, "B상점", "TOP", "TSHIRT");
+            ProductDocument adidas = createProductDocument("3", "아디다스 반팔", 9000L, 2, "C상점", "TOP", "TSHIRT");
 
             when(hit1.getContent()).thenReturn(nike1);
             when(hit2.getContent()).thenReturn(nike2);
@@ -464,8 +465,8 @@ class ProductServiceTest {
             SearchHit<ProductDocument> hit1 = mock(SearchHit.class);
             SearchHit<ProductDocument> hit2 = mock(SearchHit.class);
 
-            ProductDocument doc1 = createProductDocument("1", "티셔츠1", 10000L, 5, "상점1", "티셔츠");
-            ProductDocument doc2 = createProductDocument("2", "티셔츠2", 20000L, 3, "상점2", "티셔츠");
+            ProductDocument doc1 = createProductDocument("1", "티셔츠1", 10000L, 5, "상점1", "TOP","TSHIRT");
+            ProductDocument doc2 = createProductDocument("2", "티셔츠2", 20000L, 3, "상점2", "TOP","TSHIRT");
 
             when(hit1.getContent()).thenReturn(doc1);
             when(hit2.getContent()).thenReturn(doc2);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #239 
- [Notion : ELS 검색 성능 향상](https://www.notion.so/ELS-30d15a01205480c28cb9e5b7cb57ed7e?source=copy_link)
---

## 🧩 구현한 기능
- [x] 일반 검색 시 키워드를 상품 명이 아닌 카테고리로 하여 검색
- [x] 하위 카테고리 선택 시 하위 카테고리에 대한 전체 상품 조회
- [x] 하위 카테고리 선택 시 선택된 카테고리 중 상품 검색

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

상품 엔티티의 카테고리를 2계층으로 하여 TOP과 PANTS를 상위 카테고리로 하고 이하 하위 카테고리를 두어 카테고리를 기반으로 정확한 상품 검색을 목표로 한다.
자세한 구현 내용은 아래 노션 링크 참고 부탁드립니다.
- [Notion : ELS 검색 성능 향상](https://www.notion.so/ELS-30d15a01205480c28cb9e5b7cb57ed7e?source=copy_link)

---

## 🔄 기능 흐름
1. 사용자가 카테고리 선택 후 상품 검색 요청
2. 서버에서 선택된 카테고리 기반으로 상품 검색 처리
3. 결과를 ELS  JSON response 형태로 반환

---

## ✨ 변동 사항
### 🔧 코드 변경
- 기존 로직에서 카테고리를 키워드 방식으로 변경
- 공통 로직 리팩토링
    - 추가된 서비스 코드와의 코드 중복으로 중복된 코드 메서드로 변환 
    - synonym 변경
    - **document에 2계층 카테고리 구조 반영**
    - 일관되지 않은 `@RequestParam` 사용 변경

### 🗂 구조 변경
- 패키지 구조 변경 여부
- 새로 추가 / 삭제된 클래스

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] 단위 테스트  수정
- [x] Postman 테스트
- 자세한 테스트 결과는 노션 링크에서 확인할 수 있습니다.

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한지 확인 부탁드립니다.
- 예외 처리 방식에 대한 의견을 주시면 좋겠습니다.


---

## 🚀 예상 추가 작업
- [ ] 필터링 기능 구현
- [ ] 성능 개선
