### PR TITLE
[#256] Oauth2 에서 로그인을 할 때도 계좌 생성을 하는 문제점 해결

### DIFF
--- a/user-service/src/main/java/io/codebuddy/userservice/domain/auth/oauth/service/OauthService.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/auth/oauth/service/OauthService.java
@@ -15,6 +15,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.swing.*;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -42,25 +43,38 @@ public class OauthService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException("Email not found from OAuth2 provider");
         }
 
-        // 기존 회원이면 조회, 없으면 생성
-        Member member = memberRepository.findByEmail(email)
-                .orElseGet(() -> memberRepository.save(
-                        Member.builder()
-                                .username(name)
-                                .memberId(email)
-                                .email(email)
-                                .password("OAUTH_USER")
-                                .role(Role.MEMBER)
-                                .build()
-                ));
+        /* 기존의 문제점: orElseGet() 람다 내부에서만 생성되지만 외부에서 구분이 불가능 하다 -> 기존 회원도 매번 계좌 생성 요청*/
+        // 기존 회원 조회
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
+        boolean isNewMember = optionalMember.isEmpty();
+        if (optionalMember.isEmpty()) {
+            // 신규 회원 생성
+            Member newMember = Member.builder()
+                    .username(name)
+                    .memberId(email)
+                    .email(email)
+                    .password("OAUTH_USER")
+                    .role(Role.MEMBER)
+                    .build();
+            memberRepository.save(newMember);
+            optionalMember = Optional.of(newMember);
+        }
+
+        // Optional에서 실제 Member 객체 꺼내기
+        Member member = optionalMember.get();
         MemberDetails memberDetails = new MemberDetails(member, oAuth2User.getAttributes());
 
         // Main-Service로 계좌 생성 요청 (동기 통신)
-        try {
-            payServiceClient.createAccount(new AccountCreateRequest(member.getId()));
-        } catch (Exception e) {
-            throw new OAuth2AuthenticationException("계좌 생성 실패: "+ e.getMessage());
+        // "신규회원일 때만" 계좌 생성
+        if (isNewMember) {
+            try {
+                payServiceClient.createAccount(new AccountCreateRequest(member.getId()));
+                log.info("Account created for new member: {}", member.getId());
+            } catch (Exception e) {
+                log.warn("PayService account creation failed : memberId={}, error={}",
+                        member.getId(), e.getMessage(), e);
+            }
         }
 
         return memberDetails;


### PR DESCRIPTION
Oauth2 로그인에서 중복 계좌생성 문제를 해결하도록 코드를 수정

## 🔗 관련 이슈
- Oauth2 에서 회원가입이 아닌 로그인에서도 계좌 생성을 하여 한 사람당 중복 계좌 생성을 하게 되는 문제점 발생

---

## 🧩 구현한 기능
- [x] 주요 기능 1 회원가입일 때만 계좌 생성을 하고 로그인일 때는 계좌 생성을 하지 않는 호출 방식으로 수정하기

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

회원가입일 때만 계좌생성을 하도록 호출하고 로그인일 때에는 계좌생성을 하지 않도록 구현하여 중복 계좌 생성의 에러를 해결하였습니다.
---

## 🔄 기능 흐름
1. Oauth2 로그인 페이지에 접속
2. 해당 로그인한 회원이 새로운 회원인지 기존의 회원인지 판단
3. 기존의 회원이면 계좌 생성을 하지 않고 새로운 회원인 경우에만 계좌생성을 진행

---

## ✨ 변동 사항
### 🔧 코드 변경
- Oauth2Service 모듈에서 새로운 회원과 기존의 회원을 정의하고 계좌 생성 호출 부분을 수정
---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료
- [x] Postman / Swagger 테스트

---

## 🔍 리뷰 요청 포인트
- 이 로직/설계 방식이 적절한지 확인 부탁드립니다.
- 예외 처리 방식에 대한 의견을 주시면 좋겠습니다.
- 성능 또는 확장성 관점에서 개선할 부분이 있는지 봐주세요.

---

## 🚀 예상 추가 작업
- [ ] redirect url 설정 및 
- [ ] redirect url의 접근 권한을 열어두는 Security Config 수정 필요
