### PR TITLE
[#271] cors 설정 변경으로 인한 프론트엔드 엔드포인트 접근 허용

### DIFF
--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/security/JwtTokenVerifier.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/security/JwtTokenVerifier.java
@@ -32,7 +32,7 @@ public class JwtTokenVerifier implements TokenVerifier {
         String userServiceUrl = instances.get(0).getUri().toString();
 
         VerifiedUserResponse response = restClient.post()
-                .uri(userServiceUrl + "/api/v1/auth/verify") //verify 주소로 요청
+                .uri(userServiceUrl + "/api/v1/auth/verify") // verify 주소로 요청
                 .header(HttpHeaders.AUTHORIZATION, authHeader)
                 .retrieve()
                 .body(VerifiedUserResponse.class);
@@ -41,9 +41,9 @@ public class JwtTokenVerifier implements TokenVerifier {
             throw new IllegalStateException("Empty verification response from user-service");
         }
 
-        return new VerifiedUser(response.userId().toString(), response.role());
+        return new VerifiedUser(response.memberId().toString(), response.role());
     }
 
-    private record VerifiedUserResponse(Long userId, String role) {
+    private record VerifiedUserResponse(Long memberId, String role) {
     }
 }

--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/SecurityConfig.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                 return http
                                 .cors(cors -> cors.configurationSource(request -> {
                                         CorsConfiguration config = new CorsConfiguration();
-                                        config.setAllowedOrigins(Collections.singletonList("http://localhost:8090")); // Swagger 주소
+                                        config.setAllowedOrigins(java.util.List.of("http://localhost:8090",
+                                                        "http://localhost:5173")); // Swagger 및 Frontend 허용
                                         config.setAllowedMethods(Collections.singletonList("*"));
                                         config.setAllowedHeaders(Collections.singletonList("*"));
                                         config.setAllowCredentials(true);
@@ -59,20 +60,22 @@ public class SecurityConfig {
                                 .csrf(csrf -> csrf.disable())
                                 .authorizeHttpRequests((request) -> request
                                                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                                                .requestMatchers( "/login-success").permitAll()
+                                                .requestMatchers("/login-success").permitAll()
                                                 .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                                                 .requestMatchers("/api/v1/auth/**").permitAll()
                                                 .requestMatchers("/api/v1/authc/**").permitAll()
                                                 // 내부 서비스 간 통신용 API - 인증 불필요
                                                 .requestMatchers("/internal/**").permitAll()
                                                 // Prometheus 테스트를 위해 인가, 배포 시 주석 처리된 부분 활용
-                                                //.requestMatchers("/actuator/prometheus", "/actuator/health", "/actuator/info").permitAll()
-                                                //.requestMatchers("/actuator/**").denyAll()
+                                                // .requestMatchers("/actuator/prometheus", "/actuator/health",
+                                                // "/actuator/info").permitAll()
+                                                // .requestMatchers("/actuator/**").denyAll()
                                                 .requestMatchers("/actuator/**").permitAll()
 
-
                                                 // swagger 허용범위 설정
-                                                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                                                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**",
+                                                                "/swagger-ui.html")
+                                                .permitAll()
                                                 .requestMatchers("/closetbuddy-user/v3/api-docs").permitAll()
                                                 .requestMatchers("/closetbuddy-main/v3/api-docs").permitAll()
 
@@ -112,7 +115,6 @@ public class SecurityConfig {
                                  * .logoutSuccessHandler(apiLogoutSuccessHandler)
                                  * )
                                  */
-
 
                                 // OAuth2 로그인 활성화
                                 .oauth2Login(oauth2 -> oauth2 // formLogin 후 위치 유지


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #271

---

## 🧩 구현한 기능
- [ ] cors 설정 변경으로 인한 프론트엔드 요청 엔드포인트 접근 허용
- [ ] 로그인으로 발급 받은 토큰 검증시 user-id가 아닌 member-id를 사용하도록 변경

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 로그인 요청
2. 프론트엔드의 요청이 cors 검사를 통과
3. 정상적인 토큰 발급

---

## 🧪 테스트 방법
- [ ] 로컬 테스트 완료
- [ ] Postman / Swagger 테스트


---

## 🚀 예상 추가 작업
- [ ] 인수테스트
