### PR TITLE
[#276] 배포 환경의 gateway를 통한 요청의 Origin 헤더 cors 검사 설정 빈 주입

### DIFF
--- a/gateway-service/src/main/java/io/codebuddy/gatewayservice/config/CorsConfig.java
+++ b/gateway-service/src/main/java/io/codebuddy/gatewayservice/config/CorsConfig.java
@@ -1,0 +1,43 @@
+package io.codebuddy.gatewayservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    // 브라우저를 통해 주입된 Origin 헤더가 cors 검사를 통과할 수 있도록 허용
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // 허용할 Origin
+        config.setAllowedOrigins(List.of(
+                "https://closet-buddy.chlab.org",
+                "http://localhost:5173",    // 로컬 개발용
+                "http://localhost:80"
+        ));
+
+        // 허용할 HTTP 메서드
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+
+        // 허용할 헤더
+        config.setAllowedHeaders(List.of("*"));
+
+        // 인증 정보 허용 (Authorization 헤더 등)
+        config.setAllowCredentials(true);
+
+        // preflight 캐싱을 설정하여 불필요하게 OPTION 요청을 하지 않도록 1시간 캐싱
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #276

---

## 🧩 구현한 기능
- [x] cors 검사시 Origin 헤더가 검사를 통과할 수 있도록 허용

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 브라우저를 통해 Origin 헤더가 주입된 요청을 전송
2. gateway를 통해 요청 라우팅
3. cors 검사 수행시 주입되어 있는 Origin 헤더를 검사후 통과
4. 요청 수행 및 응답 반환

---

## ✨ 변동 사항
### 🔧 코드 변경
- cors 검사시 허용된 목록이 없어 브라우저를 통해 주입된 Origin 헤더가 cors 검사를 통과할 수 있도록 bean 주입

---

## 🧪 테스트 방법
- [x] 로컬 테스트 완료

---

## 🔍 리뷰 요청 포인트
- 배포 환경에서 해당 bean 주입을 통해 정상적으로 브라우저 요청이 통과되는지 검토해 주세요

---

## 🚀 예상 추가 작업
- [ ] 배포
