### PR TITLE
배포 환경의 통신 요청시 CORS 검사로 인한 접근 거부 문제 해결

### DIFF
--- a/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/SecurityConfig.java
+++ b/user-service/src/main/java/io/codebuddy/userservice/domain/common/config/SecurityConfig.java
@@ -48,10 +48,10 @@ public class SecurityConfig {
         public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
                 return http
+                                // Gateway에서 CORS를 검증하므로, 내부 서비스에서는 모든 Origin 허용
                                 .cors(cors -> cors.configurationSource(request -> {
                                         CorsConfiguration config = new CorsConfiguration();
-                                        config.setAllowedOrigins(java.util.List.of("http://localhost:8090",
-                                                        "http://localhost:5173")); // Swagger 및 Frontend 허용
+                                        config.setAllowedOriginPatterns(Collections.singletonList("*"));
                                         config.setAllowedMethods(Collections.singletonList("*"));
                                         config.setAllowedHeaders(Collections.singletonList("*"));
                                         config.setAllowCredentials(true);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #276

---

## 🧩 구현한 기능
- [ ] gateway에서 CORS 검사시 통과할 헤더 명시
- [ ] user-service 접근 통신은 내부 통신이므로 CORS 검사시 OriginPttern은 허용

> 어떤 문제를 해결했는지, 핵심 구현 내용을 간단히 작성해주세요.

---

## 🔄 기능 흐름
1. 사용자가 회원가입 요청
2. 브라우저가 Origin헤더를 주입해 요청
3. gateway는 허용된 리스트에 Origin헤더가 있으므로 통과
4. user-service는 SpringSecurity filter chain 설정으로 Origin헤더 패턴은 검사하지 않고 통과

---

## ✨ 변동 사항
### 🔧 코드 변경
- user-service SpringSecurity FilterChain 수정

### 🗂 구조 변경
- 구조 변경 없음

---

## 🧪 테스트 방법
- [ ] 배포환경 테스트 필요

---

## 🔍 리뷰 요청 포인트
- 우선적으로 user-service에서 cors설정을 모든 OriginPattern을 검사하지 않도록 처리하였는데, 더 나은 처리 방법이 있다면 공유 바랍니다.

---

## 🚀 예상 추가 작업
- [ ] 배포
